### PR TITLE
feat: OpenAIで選択範囲/ページ本文を要約

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "description": "個人用のブラウザユーティリティ集（テーブルソート、AI連携など）",
   "permissions": ["activeTab", "contextMenus", "storage"],
+  "host_permissions": ["https://api.openai.com/*"],
   "action": {
     "default_popup": "popup.html",
     "default_icon": {

--- a/popup.css
+++ b/popup.css
@@ -26,8 +26,17 @@ body {
   font-family: "Segoe UI", "Helvetica Neue", system-ui, sans-serif;
   font-size: 14px;
   color: var(--text);
-  background: radial-gradient(circle at 20% 20%, rgba(62, 207, 142, 0.08), transparent 30%),
-    radial-gradient(circle at 80% 0%, rgba(123, 220, 247, 0.08), transparent 28%),
+  background:
+    radial-gradient(
+      circle at 20% 20%,
+      rgba(62, 207, 142, 0.08),
+      transparent 30%
+    ),
+    radial-gradient(
+      circle at 80% 0%,
+      rgba(123, 220, 247, 0.08),
+      transparent 28%
+    ),
     var(--bg);
 }
 
@@ -90,7 +99,11 @@ body {
 }
 
 .nav-item.active {
-  background: linear-gradient(135deg, rgba(62, 207, 142, 0.22), rgba(123, 220, 247, 0.18));
+  background: linear-gradient(
+    135deg,
+    rgba(62, 207, 142, 0.22),
+    rgba(123, 220, 247, 0.18)
+  );
   color: #fff;
   box-shadow: inset 0 0 0 1px rgba(62, 207, 142, 0.45);
 }
@@ -277,7 +290,11 @@ body {
 }
 
 .card.secondary {
-  background: linear-gradient(140deg, rgba(62, 207, 142, 0.07), rgba(19, 27, 43, 0.98));
+  background: linear-gradient(
+    140deg,
+    rgba(62, 207, 142, 0.07),
+    rgba(19, 27, 43, 0.98)
+  );
 }
 
 .card-header {
@@ -311,7 +328,10 @@ body {
   padding: 10px 14px;
   font-weight: 700;
   cursor: pointer;
-  transition: transform 0.08s ease, box-shadow 0.12s ease, background 0.2s ease;
+  transition:
+    transform 0.08s ease,
+    box-shadow 0.12s ease,
+    background 0.2s ease;
 }
 
 .btn-primary {
@@ -415,6 +435,24 @@ body {
   align-items: center;
   flex-wrap: wrap;
   margin: 8px 0 6px;
+}
+
+.summary-output {
+  width: 100%;
+  min-height: 160px;
+  padding: 12px;
+  margin-top: 10px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--panel-soft);
+  color: var(--text);
+  resize: vertical;
+  line-height: 1.5;
+  font-size: 13px;
+}
+
+.summary-output::placeholder {
+  color: #7d86a2;
 }
 
 .field-label {

--- a/popup.html
+++ b/popup.html
@@ -10,9 +10,17 @@
     <div class="app-shell">
       <aside class="sidebar">
         <div class="sidebar-brand" aria-hidden="true">MB</div>
-        <button class="nav-item active" data-target="pane-table" aria-label="テーブルソート">
+        <button
+          class="nav-item active"
+          data-target="pane-table"
+          aria-label="テーブルソート"
+        >
           <span class="nav-icon">⇅</span>
           <span class="nav-label">テーブル</span>
+        </button>
+        <button class="nav-item" data-target="pane-summary" aria-label="要約">
+          <span class="nav-icon">📝</span>
+          <span class="nav-label">要約</span>
         </button>
         <button class="nav-item" data-target="pane-settings" aria-label="設定">
           <span class="nav-icon">⚙</span>
@@ -23,7 +31,11 @@
       <main class="content">
         <header class="content-header">
           <div class="title-block">
-            <img src="images/logo.png" alt="My Browser Utilsのロゴ" class="hero-logo" />
+            <img
+              src="images/logo.png"
+              alt="My Browser Utilsのロゴ"
+              class="hero-logo"
+            />
             <div class="title-text">
               <p class="eyebrow">MY BROWSER UTILS</p>
               <div class="title-row">
@@ -36,14 +48,23 @@
           <div class="cta-pill">ワンクリックで整列</div>
         </header>
 
-        <section class="pane active" id="pane-table" role="tabpanel" aria-label="テーブルソート">
+        <section
+          class="pane active"
+          id="pane-table"
+          role="tabpanel"
+          aria-label="テーブルソート"
+        >
           <div class="pane-intro">
             <div>
               <p class="pane-eyebrow">テーブルソート</p>
               <h2>いま開いているページの表に並び替えを付与</h2>
-              <p class="muted">ヘッダーをクリックするだけで昇順/降順を切り替え。動的に増えるテーブルも自動で監視します。</p>
+              <p class="muted">
+                ヘッダーをクリックするだけで昇順/降順を切り替え。動的に増えるテーブルも自動で監視します。
+              </p>
               <div class="action-row">
-                <button id="enable-table-sort" class="btn btn-primary">このタブで実行</button>
+                <button id="enable-table-sort" class="btn btn-primary">
+                  このタブで実行
+                </button>
                 <label class="checkbox-inline">
                   <input type="checkbox" id="auto-enable-sort" />
                   開いたら自動で有効化
@@ -52,7 +73,9 @@
             </div>
             <div class="meta-card">
               <p class="meta-title">Autoモード</p>
-              <p class="meta-note">登録したURLパターンで自動起動。手動トリガーと併用できます。</p>
+              <p class="meta-note">
+                登録したURLパターンで自動起動。手動トリガーと併用できます。
+              </p>
             </div>
           </div>
 
@@ -65,7 +88,9 @@
                 </div>
                 <span class="chip chip-soft">ワイルドカード対応</span>
               </div>
-              <p class="card-copy">URLにマッチしたページでは読み込み直後からテーブルソートを有効化します。</p>
+              <p class="card-copy">
+                URLにマッチしたページでは読み込み直後からテーブルソートを有効化します。
+              </p>
 
               <div class="pattern-input-group">
                 <input
@@ -78,7 +103,11 @@
                 <button id="add-pattern" class="btn btn-ghost">追加</button>
               </div>
 
-              <div id="pattern-list" class="pattern-list" aria-live="polite"></div>
+              <div
+                id="pattern-list"
+                class="pattern-list"
+                aria-live="polite"
+              ></div>
             </div>
 
             <div class="card secondary">
@@ -89,24 +118,87 @@
                 </div>
               </div>
               <ul class="bullet-list">
-                <li>「このタブで実行」を押すだけで、ページ内の全テーブルにソート機能が付きます。</li>
-                <li>自動モードON＋パターン登録で、対象ページは開くだけで有効化。</li>
+                <li>
+                  「このタブで実行」を押すだけで、ページ内の全テーブルにソート機能が付きます。
+                </li>
+                <li>
+                  自動モードON＋パターン登録で、対象ページは開くだけで有効化。
+                </li>
                 <li>ヘッダーをクリックすると昇順/降順を切り替えます。</li>
               </ul>
             </div>
           </div>
         </section>
 
-        <section class="pane" id="pane-settings" role="tabpanel" aria-label="設定">
+        <section
+          class="pane"
+          id="pane-summary"
+          role="tabpanel"
+          aria-label="要約"
+        >
+          <div class="pane-intro">
+            <div>
+              <p class="pane-eyebrow">AI要約</p>
+              <h2>選択範囲 or ページ本文をまとめる</h2>
+              <p class="muted">
+                ページ上でテキストを選択していればその範囲、未選択ならページ本文（タブ内テキスト）を要約します。
+              </p>
+              <div class="action-row">
+                <button id="summarize-tab" class="btn btn-primary">
+                  このタブを要約
+                </button>
+                <button id="copy-summary" class="btn btn-ghost" disabled>
+                  コピー
+                </button>
+              </div>
+            </div>
+            <div class="meta-card">
+              <p class="meta-title">事前準備</p>
+              <p class="meta-note">
+                「設定」タブで OpenAI API Token を保存してください。
+              </p>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card-header">
+              <div>
+                <p class="card-eyebrow">Output</p>
+                <h3>要約結果</h3>
+              </div>
+              <span class="chip chip-soft" id="summary-source-chip">-</span>
+            </div>
+            <textarea
+              id="summary-output"
+              class="summary-output"
+              placeholder="ここに要約が表示されます"
+              readonly
+            ></textarea>
+            <p class="hint">
+              結果はコピーしてメモやチャットに貼り付けられます。
+            </p>
+          </div>
+        </section>
+
+        <section
+          class="pane"
+          id="pane-settings"
+          role="tabpanel"
+          aria-label="設定"
+        >
           <div class="pane-intro">
             <div>
               <p class="pane-eyebrow">設定</p>
               <h2>OpenAI API Token</h2>
-              <p class="muted">今後のAI連携機能で使用するトークンを保存します。</p>
+              <p class="muted">
+                今後のAI連携機能で使用するトークンを保存します。
+              </p>
             </div>
             <div class="meta-card">
               <p class="meta-title">保存先</p>
-              <p class="meta-note">ブラウザのローカルストレージに平文で保存します。必要に応じてクリアしてください。</p>
+              <p class="meta-note">
+                ブラウザのローカルストレージに平文で保存します。必要に応じてクリアしてください。
+              </p>
             </div>
           </div>
 
@@ -119,7 +211,9 @@
               <span class="chip chip-soft">必須</span>
             </div>
 
-            <label class="field-label" for="openai-token">OpenAI API Token</label>
+            <label class="field-label" for="openai-token"
+              >OpenAI API Token</label
+            >
             <div class="token-row">
               <input
                 type="password"
@@ -128,10 +222,16 @@
                 class="token-input"
                 autocomplete="off"
               />
-              <button id="save-openai-token" class="btn btn-primary">保存</button>
-              <button id="clear-openai-token" class="btn btn-ghost">クリア</button>
+              <button id="save-openai-token" class="btn btn-primary">
+                保存
+              </button>
+              <button id="clear-openai-token" class="btn btn-ghost">
+                クリア
+              </button>
             </div>
-            <p class="hint">トークンは暗号化されずに保存されます。共有環境では入力後にクリアすることをおすすめします。</p>
+            <p class="hint">
+              トークンは暗号化されずに保存されます。共有環境では入力後にクリアすることをおすすめします。
+            </p>
           </div>
         </section>
       </main>

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,19 +1,40 @@
 // Background Service Worker
 
-type ContentScriptMessage = {
-  action: "showNotification";
-  message: string;
+type SummarySource = "selection" | "page";
+
+type SummaryTarget = {
+  text: string;
+  source: SummarySource;
+  title?: string;
+  url?: string;
 };
 
-const CONTEXT_MENU_ID = "ai-process-text";
+type ContentScriptMessage =
+  | { action: "showNotification"; message: string }
+  | { action: "getSummaryTargetText" }
+  | { action: "showSummaryOverlay"; summary: string; source: SummarySource };
+
+type BackgroundRequest = { action: "summarizeTab"; tabId: number };
+
+type BackgroundResponse =
+  | { ok: true; summary: string; source: SummarySource }
+  | { ok: false; error: string };
+
+type LocalStorageData = {
+  openaiApiToken?: string;
+};
+
+const CONTEXT_MENU_ID = "ai-summarize";
 
 chrome.runtime.onInstalled.addListener(() => {
   console.log("My Browser Utils installed");
 
-  chrome.contextMenus.create({
-    id: CONTEXT_MENU_ID,
-    title: "選択テキストをAIで処理",
-    contexts: ["selection"],
+  chrome.contextMenus.removeAll(() => {
+    chrome.contextMenus.create({
+      id: CONTEXT_MENU_ID,
+      title: "ページ/選択範囲を要約",
+      contexts: ["page", "selection"],
+    });
   });
 });
 
@@ -21,29 +42,186 @@ chrome.contextMenus.onClicked.addListener(
   (info: chrome.contextMenus.OnClickData, tab?: chrome.tabs.Tab) => {
     if (info.menuItemId !== CONTEXT_MENU_ID) return;
 
-    const selectedText = info.selectionText;
-    console.log("Selected text:", selectedText);
-
     const tabId = tab?.id;
     if (tabId === undefined) {
       return;
     }
 
-    const message: ContentScriptMessage = {
-      action: "showNotification",
-      message: "AI処理機能は開発中です",
-    };
+    void (async () => {
+      await sendMessageToTab(tabId, {
+        action: "showNotification",
+        message: "要約中...",
+      });
 
-    chrome.tabs.sendMessage(tabId, message);
+      const selection = info.selectionText?.trim() ?? "";
+      const target: SummaryTarget = selection
+        ? {
+            text: selection,
+            source: "selection",
+            title: tab?.title,
+            url: tab?.url,
+          }
+        : await sendMessageToTab(tabId, { action: "getSummaryTargetText" });
+
+      const result = await summarizeWithOpenAI(target);
+      if (!result.ok) {
+        await sendMessageToTab(tabId, {
+          action: "showNotification",
+          message: result.error,
+        });
+        return;
+      }
+
+      await sendMessageToTab(tabId, {
+        action: "showSummaryOverlay",
+        summary: result.summary,
+        source: result.source,
+      });
+    })();
   },
 );
 
 chrome.runtime.onMessage.addListener(
   (
-    _request: unknown,
+    request: BackgroundRequest,
     _sender: chrome.runtime.MessageSender,
-    _sendResponse: (response?: unknown) => void,
+    sendResponse: (response?: BackgroundResponse) => void,
   ) => {
+    if (request.action === "summarizeTab") {
+      void (async () => {
+        try {
+          const target = await sendMessageToTab<
+            ContentScriptMessage,
+            SummaryTarget
+          >(request.tabId, { action: "getSummaryTargetText" });
+
+          const result = await summarizeWithOpenAI(target);
+          sendResponse(result);
+        } catch (error) {
+          sendResponse({
+            ok: false,
+            error:
+              error instanceof Error ? error.message : "要約に失敗しました",
+          });
+        }
+      })();
+      return true;
+    }
+
     return true;
   },
 );
+
+function sendMessageToTab<TRequest, TResponse>(
+  tabId: number,
+  message: TRequest,
+): Promise<TResponse> {
+  return new Promise((resolve, reject) => {
+    chrome.tabs.sendMessage(tabId, message, (response: TResponse) => {
+      const err = chrome.runtime.lastError;
+      if (err) {
+        reject(new Error(`このページでは実行できません（${err.message}）`));
+        return;
+      }
+      resolve(response);
+    });
+  });
+}
+
+async function summarizeWithOpenAI(
+  target: SummaryTarget,
+): Promise<BackgroundResponse> {
+  const { openaiApiToken } = (await chrome.storage.local.get([
+    "openaiApiToken",
+  ])) as LocalStorageData;
+
+  if (!openaiApiToken) {
+    return {
+      ok: false,
+      error:
+        "OpenAI API Tokenが未設定です（ポップアップの「設定」タブで設定してください）",
+    };
+  }
+
+  const MAX_INPUT_CHARS = 20000;
+  const rawText = target.text.trim();
+  if (!rawText) {
+    return { ok: false, error: "要約対象のテキストが見つかりませんでした" };
+  }
+
+  const clippedText =
+    rawText.length > MAX_INPUT_CHARS
+      ? `${rawText.slice(0, MAX_INPUT_CHARS)}\n\n(以下略)`
+      : rawText;
+
+  const meta =
+    target.title || target.url
+      ? `\n\n---\nタイトル: ${target.title ?? "-"}\nURL: ${target.url ?? "-"}`
+      : "";
+
+  const body = {
+    model: "gpt-4o-mini",
+    temperature: 0.2,
+    messages: [
+      {
+        role: "system",
+        content:
+          "あなたは日本語の要約アシスタントです。入力テキストを読み、要点を短く整理して出力してください。",
+      },
+      {
+        role: "user",
+        content: [
+          "次のテキストを日本語で要約してください。",
+          "",
+          "要件:",
+          "- 重要ポイントを箇条書き(3〜7個)",
+          "- 最後に一文で結論/要約",
+          "- 事実と推測を混同しない",
+          "",
+          clippedText + meta,
+        ].join("\n"),
+      },
+    ],
+  };
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${openaiApiToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  const json: unknown = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message =
+      typeof json === "object" &&
+      json !== null &&
+      "error" in json &&
+      typeof (json as { error?: unknown }).error === "object" &&
+      (json as { error: { message?: unknown } }).error !== null &&
+      typeof (json as { error: { message?: unknown } }).error.message ===
+        "string"
+        ? (json as { error: { message: string } }).error.message
+        : `OpenAI APIエラー: ${response.status}`;
+    return { ok: false, error: message };
+  }
+
+  const summary = extractChatCompletionText(json);
+  if (!summary) {
+    return { ok: false, error: "要約結果の取得に失敗しました" };
+  }
+
+  return { ok: true, summary, source: target.source };
+}
+
+function extractChatCompletionText(json: unknown): string | null {
+  if (typeof json !== "object" || json === null) return null;
+  const choices = (json as { choices?: unknown }).choices;
+  if (!Array.isArray(choices) || choices.length === 0) return null;
+  const first = choices[0] as { message?: { content?: unknown } };
+  const content = first?.message?.content;
+  if (typeof content !== "string") return null;
+  return content.trim();
+}


### PR DESCRIPTION
## 概要
OpenAI API Token（ポップアップの「設定」タブで保存）を使って、選択範囲またはページ本文を要約できるようにしました。

## 変更内容
- ポップアップに「要約」タブを追加し、「このタブを要約」→ 結果表示/コピーを追加
- 右クリックメニューに「ページ/選択範囲を要約」を追加（結果はページ右下のオーバーレイ表示）
- OpenAI API 呼び出しのために host_permissions（https://api.openai.com/*）を追加

## 動作仕様
- テキスト選択がある場合: 選択範囲を要約
- 選択がない場合: ページ本文（タブ内テキスト）を要約

## 確認方法
1. 拡張機能ポップアップ → 「設定」タブで OpenAI API Token を保存
2. 任意のページで（任意）テキストを選択
3. 次のいずれかで要約
   - ポップアップ → 「要約」タブ → 「このタブを要約」
   - 右クリック → 「ページ/選択範囲を要約」

## チェック
- mise run format
- mise run ci
