### PR TITLE
fix: テーブルソートのURLパターン登録/判定を改善（クエリ/ハッシュ許容）

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -73,12 +73,24 @@
       .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
       .replace(/\*/g, ".*");
 
-    return new RegExp(`^${escaped}$`);
+    const shouldAllowQueryHashSuffix = !/[?#]/.test(pattern);
+    const allowOptionalTrailingSlash =
+      shouldAllowQueryHashSuffix &&
+      !pattern.endsWith("/") &&
+      !pattern.includes("*");
+
+    const optionalTrailingSlash = allowOptionalTrailingSlash ? "(?:/)?" : "";
+    const optionalQueryHashSuffix = shouldAllowQueryHashSuffix
+      ? "(?:[?#].*)?"
+      : "";
+
+    return new RegExp(
+      `^${escaped}${optionalTrailingSlash}${optionalQueryHashSuffix}$`,
+    );
   }
 
   function matchesAnyPattern(patterns: string[]): boolean {
-    const url = window.location.href;
-    const urlWithoutProtocol = url.replace(/^https?:\/\//, "");
+    const urlWithoutProtocol = window.location.href.replace(/^https?:\/\//, "");
 
     return patterns.some((pattern) => {
       const patternWithoutProtocol = pattern.replace(/^https?:\/\//, "");

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -402,7 +402,11 @@
 
     if (/\s/.test(pattern)) return false;
 
-    if (!/^[a-zA-Z0-9.*\\-_/:]+$/.test(pattern)) return false;
+    // URLっぽい文字（? # & = % など）も許可して、コピペしたURLをそのまま登録できるようにする
+    // RFC3986 の予約文字 + % + ワイルドカード(*) を許可
+    if (!/^[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%*-]+$/.test(pattern)) {
+      return false;
+    }
 
     return true;
   }


### PR DESCRIPTION
## 概要

- URLをコピペしたときに「無効なパターンです」にならないよう、URLで使われる文字（`?` `#` `&` `=` `%` など）を許可
- パターン側にクエリ/ハッシュが含まれない場合、現在URLのクエリ/ハッシュ/末尾スラッシュを許容してマッチ（例: `index.html?x=1` / `index.html#/route`）
- `www.smbc-card.com/memx/web_meisai/top/index.html` のようなURLでも、そのまま登録→自動有効化されるようにする

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
