### PR TITLE
fix: ポップアップの要約/設定タブに移動できない問題を修正

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -82,6 +82,8 @@ body {
   gap: 6px;
   cursor: pointer;
   transition: all 0.2s ease;
+  text-decoration: none;
+  font: inherit;
 }
 
 .nav-item .nav-icon {
@@ -208,6 +210,14 @@ body {
 
 .pane.active {
   display: flex;
+}
+
+.pane:target {
+  display: flex;
+}
+
+body:has(.pane:target) .pane.active:not(:target) {
+  display: none;
 }
 
 .pane-intro {

--- a/popup.html
+++ b/popup.html
@@ -10,22 +10,39 @@
     <div class="app-shell">
       <aside class="sidebar">
         <div class="sidebar-brand" aria-hidden="true">MB</div>
-        <button
+        <a
           class="nav-item active"
           data-target="pane-table"
+          href="#pane-table"
+          role="tab"
+          aria-controls="pane-table"
           aria-label="テーブルソート"
         >
           <span class="nav-icon">⇅</span>
           <span class="nav-label">テーブル</span>
-        </button>
-        <button class="nav-item" data-target="pane-summary" aria-label="要約">
+        </a>
+        <a
+          class="nav-item"
+          data-target="pane-summary"
+          href="#pane-summary"
+          role="tab"
+          aria-controls="pane-summary"
+          aria-label="要約"
+        >
           <span class="nav-icon">📝</span>
           <span class="nav-label">要約</span>
-        </button>
-        <button class="nav-item" data-target="pane-settings" aria-label="設定">
+        </a>
+        <a
+          class="nav-item"
+          data-target="pane-settings"
+          href="#pane-settings"
+          role="tab"
+          aria-controls="pane-settings"
+          aria-label="設定"
+        >
           <span class="nav-icon">⚙</span>
           <span class="nav-label">設定</span>
-        </button>
+        </a>
       </aside>
 
       <main class="content">

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -585,11 +585,15 @@
 
   function setupNavigation(): void {
     const navItems = Array.from(
-      document.querySelectorAll<HTMLButtonElement>(".nav-item"),
+      document.querySelectorAll<HTMLElement>(".nav-item"),
     );
     const panes = Array.from(document.querySelectorAll<HTMLElement>(".pane"));
-    const heroChip = document.getElementById("hero-chip") as HTMLSpanElement;
-    const ctaPill = document.getElementById("cta-pill") as HTMLDivElement;
+    const heroChip = document.getElementById(
+      "hero-chip",
+    ) as HTMLSpanElement | null;
+    const ctaPill = document.getElementById(
+      "cta-pill",
+    ) as HTMLDivElement | null;
 
     const updateHero = (activeTargetId?: string): void => {
       if (!heroChip || !ctaPill) return;
@@ -608,24 +612,47 @@
       ctaPill.textContent = "ワンクリックで整列";
     };
 
+    const setActive = (targetId?: string): void => {
+      const resolvedTargetId =
+        targetId ||
+        navItems.find((item) => item.classList.contains("active"))?.dataset
+          .target ||
+        panes[0]?.id;
+      if (!resolvedTargetId) return;
+
+      navItems.forEach((nav) => {
+        const isActive = nav.dataset.target === resolvedTargetId;
+        nav.classList.toggle("active", isActive);
+        nav.setAttribute("aria-selected", isActive ? "true" : "false");
+      });
+
+      panes.forEach((pane) => {
+        pane.classList.toggle("active", pane.id === resolvedTargetId);
+      });
+
+      updateHero(resolvedTargetId);
+    };
+
+    const getTargetFromHash = (): string | undefined => {
+      const hash = window.location.hash.replace(/^#/, "");
+      if (!hash) return undefined;
+      if (!document.getElementById(hash)) return undefined;
+      return hash;
+    };
+
     navItems.forEach((item) => {
       item.addEventListener("click", () => {
-        navItems.forEach((nav) => nav.classList.remove("active"));
-        panes.forEach((pane) => pane.classList.remove("active"));
-
-        item.classList.add("active");
         const targetId = item.dataset.target;
-        if (targetId) {
-          document.getElementById(targetId)?.classList.add("active");
-        }
-        updateHero(targetId);
+        if (!targetId) return;
+        setActive(targetId);
       });
     });
 
-    const defaultActive = navItems.find((item) =>
-      item.classList.contains("active"),
-    )?.dataset.target;
-    updateHero(defaultActive);
+    window.addEventListener("hashchange", () => {
+      setActive(getTargetFromHash());
+    });
+
+    setActive(getTargetFromHash());
   }
 
   async function loadOpenAiToken(


### PR DESCRIPTION
## 概要

- ポップアップのサイドバーで「要約」「設定」をクリックしてもペインが切り替わらない問題を修正
- URL hash（`#pane-*`）と `:target` を使い、スクリプト未読み込み時でもタブ切り替えだけは動くようにフォールバック
- `hashchange` に追従して、ヒーロー表示・active状態を同期

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
