### PR TITLE
fix: ポップアップのタブ切替でスクロールが動く問題を修正

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -75,6 +75,7 @@ body {
   transition: all 0.2s ease;
   text-decoration: none;
   font: inherit;
+  position: relative;
 }
 
 .nav-item .nav-icon {
@@ -91,10 +92,32 @@ body {
   color: #fff;
 }
 
-.nav-item.active {
-  background: linear-gradient(135deg, rgba(62, 207, 142, 0.22), rgba(123, 220, 247, 0.18));
+.nav-item.active,
+.nav-item[aria-selected='true'] {
+  background: linear-gradient(135deg, rgba(62, 207, 142, 0.32), rgba(123, 220, 247, 0.26));
   color: #fff;
-  box-shadow: inset 0 0 0 1px rgba(62, 207, 142, 0.45);
+  box-shadow:
+    inset 0 0 0 1px rgba(62, 207, 142, 0.6),
+    0 10px 22px rgba(0, 0, 0, 0.22);
+}
+
+.nav-item.active::before,
+.nav-item[aria-selected='true']::before {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4px;
+  height: 28px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, var(--accent), var(--accent-2));
+  box-shadow: 0 0 0 2px rgba(15, 23, 36, 0.55);
+}
+
+.nav-item:focus-visible {
+  outline: 2px solid rgba(123, 220, 247, 0.8);
+  outline-offset: 2px;
 }
 
 .content {

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -530,10 +530,21 @@
     };
 
     navItems.forEach(item => {
-      item.addEventListener('click', () => {
+      item.addEventListener('click', event => {
+        // `href="#pane-..."` のデフォルト挙動（アンカーへのスクロール）を止めて、
+        // タブ切り替え時にスクロール位置が意図せず動かないようにする。
+        event.preventDefault();
+
         const targetId = item.dataset.target;
         if (!targetId) return;
+
         setActive(targetId);
+
+        // `location.hash = ...` はスクロールしてしまうので replaceState でURLだけ更新する。
+        const nextHash = `#${targetId}`;
+        if (window.location.hash !== nextHash) {
+          window.history.replaceState(null, '', nextHash);
+        }
       });
     });
 


### PR DESCRIPTION
## 概要

- ポップアップのサイドバー（タブ）クリック時に、アンカー遷移でスクロール位置が意図せず動く問題を修正
- `preventDefault` + `history.replaceState` で URL hash を更新しつつスクロールを抑制
- 選択中タブの視認性を改善（サイドバーのアクティブ表示を強化）

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
