### PR TITLE
fix: 設定タブのAPI Token保存/動作確認が反応しない

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -224,6 +224,7 @@
       </main>
     </div>
 
-    <script src="popup_bootstrap.js"></script>
+    <script src="dist/popup.js" defer></script>
+    <script src="popup_bootstrap.js" defer></script>
   </body>
 </html>

--- a/popup_bootstrap.js
+++ b/popup_bootstrap.js
@@ -1,14 +1,11 @@
 (function () {
-  var SCRIPT_SRC = 'dist/popup.js';
-
-  function showBuildError() {
+  function showError(message) {
     var existing = document.getElementById('mbu-build-error');
     if (existing) return;
 
     var banner = document.createElement('div');
     banner.id = 'mbu-build-error';
-    banner.textContent =
-      '拡張機能のスクリプトを読み込めませんでした。`pnpm install && pnpm run build` を実行してから、chrome://extensions でこの拡張機能を再読み込みしてください。';
+    banner.textContent = message;
     banner.style.cssText =
       'position: fixed;' +
       'left: 12px;' +
@@ -23,12 +20,21 @@
       'font-weight: 700;' +
       'box-shadow: 0 10px 24px rgba(0,0,0,0.3);';
 
-    document.body.appendChild(banner);
+    (document.body || document.documentElement).appendChild(banner);
   }
 
-  var script = document.createElement('script');
-  script.async = false;
-  script.src = SCRIPT_SRC;
-  script.addEventListener('error', showBuildError);
-  document.body.appendChild(script);
+  // `dist/popup.js` が読み込めていない/実行できていない場合にだけ案内を出す
+  // （Safari/Firefoxや、CSP等で動的スクリプト注入が制限される環境でも確実に表示できるようにする）
+  var loaded = !!(globalThis && globalThis.__MBU_POPUP_LOADED__);
+  if (loaded) return;
+
+  // 拡張機能ページ外（ファイルとして開いた等）でのプレビュー時の分かりやすい案内
+  if (typeof chrome === 'undefined' || !chrome.runtime) {
+    showError('このページはChrome拡張機能として読み込んでください（chrome://extensions から拡張機能を読み込みます）。');
+    return;
+  }
+
+  showError(
+    '拡張機能のスクリプトを読み込めませんでした。`pnpm install && pnpm run build` を実行してから、chrome://extensions でこの拡張機能を再読み込みしてください。',
+  );
 })();

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,4 +1,6 @@
 (() => {
+  (globalThis as unknown as { __MBU_POPUP_LOADED__?: boolean }).__MBU_POPUP_LOADED__ = true;
+
   type SyncStorageData = {
     domainPatterns?: string[];
     autoEnableSort?: boolean;

--- a/tests/popup.bootstrap.test.ts
+++ b/tests/popup.bootstrap.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('popup_bootstrap.js', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+    delete (globalThis as unknown as { __MBU_POPUP_LOADED__?: boolean }).__MBU_POPUP_LOADED__;
+  });
+
+  it('shows a banner when popup logic is not loaded', async () => {
+    vi.stubGlobal('chrome', { runtime: {} });
+
+    // @ts-expect-error - plain JS side-effect module
+    await import('../popup_bootstrap.js');
+
+    expect(document.getElementById('mbu-build-error')).not.toBeNull();
+  });
+
+  it('does nothing when popup logic is loaded', async () => {
+    (globalThis as unknown as { __MBU_POPUP_LOADED__?: boolean }).__MBU_POPUP_LOADED__ = true;
+    vi.stubGlobal('chrome', { runtime: {} });
+
+    // @ts-expect-error - plain JS side-effect module
+    await import('../popup_bootstrap.js');
+
+    expect(document.getElementById('mbu-build-error')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要
設定タブの「保存」「動作確認」が無反応に見える（`dist/popup.js` が読み込めていない/実行できていない）ケースがあったため、`popup.html` 側で `dist/popup.js` を静的に読み込み、失敗時は `popup_bootstrap.js` が案内を表示するようにしました。

## 変更内容
- `popup.html`: `dist/popup.js` を `defer` で読み込み
- `popup_bootstrap.js`: ロード失敗時のみバナー表示（拡張機能ページ外で開いた場合の案内も追加）
- `src/popup.ts`: ロード検知フラグ `__MBU_POPUP_LOADED__` をセット
- `tests/popup.bootstrap.test.ts`: バナー表示の回帰テスト

## 動作確認
- `mise run ci`
