### PR TITLE
chore(mise): mise.tomlのタスク整理

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -12,31 +12,27 @@ _.path = ["./node_modules/.bin"]
 
 [tools]
 node = "24"
-"npm:pnpm" = "10.25.0"
+"npm:pnpm" = "10.26.0"
 
 # ========================================
-# コマンド（ショートカット）
+# コマンド（実処理タスク）
 # ========================================
 
 [tasks.format]
-description = "Ultracite(Biome)でソース全体を整形"
+description = "Biomeでソース全体を整形（自動修正あり）"
 run = "pnpm run format"
 
 [tasks."lint:types"]
 description = "TypeScriptの型チェックのみ"
 run = "pnpm exec tsc --noEmit"
 
-[tasks."lint:ultracite"]
-description = "Ultracite(Biome)のチェックのみ"
+[tasks."lint:biome"]
+description = "Biomeのチェックのみ（自動修正なし）"
 run = "pnpm run lint"
 
 [tasks.test]
 description = "Vitestでユニットテストを実行"
 run = "pnpm run test"
-
-[tasks.lint]
-description = "型チェックとフォーマット検証を実行"
-depends = ["lint:types", "lint:ultracite"]
 
 [tasks.build]
 description = "TypeScriptをビルド"
@@ -49,6 +45,14 @@ run = "pnpm run clean"
 # ========================================
 # エイリアス（まとめ実行）
 # ========================================
+
+[tasks.lint]
+description = "型チェック + Biomeチェックを実行"
+depends = ["lint:types", "lint:biome"]
+
+[tasks.check]
+description = "ローカル確認（lint + test）"
+depends = ["lint", "test"]
 
 [tasks.ci]
 description = "CI 相当のチェック (lint + build)"


### PR DESCRIPTION
## 概要

開発/CIで使う `mise.toml` のタスク定義を整理し、**実処理タスク（上）**と**エイリアス（下）**が明確に分かれるようにしました。

- 実処理タスク: `format` / `lint:types` / `lint:biome` / `test` / `build` / `clean`
- エイリアス: `lint` / `check` / `ci`

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [x] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- なし -->

## 確認済み

- [x] 動作確認完了（miseタスクの実行確認）
- [x] 品質チェック通過（`mise run ci` / `pnpm run lint` + `pnpm run typecheck` + `pnpm run build` を含む）
- [ ] Terraform変更時: `terraform validate && terraform plan`

## 変更内容

- `tasks` の役割（実処理/まとめ実行）でセクション分け
- `lint:ultracite` を `lint:biome` にリネーム（実体は `ultracite check` のまま）
- ローカル確認用に `check`（`lint` + `test`）を追加
- `pnpm` のバージョンを `packageManager` に合わせて `10.26.0` に更新

## 背景

- タスクが「実処理」と「ショートカット」で混在しており、読みやすさ/呼び分けが難しかったため
- `pnpm` のバージョンが `packageManager` とズレており、環境差分の原因になり得るため

## レビュー観点

- タスク名/依存関係の整理方針が妥当か（意図しないタスクの増減がないか）
- `pnpm` バージョン更新が問題ないか（CIや開発環境への影響）

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
