### PR TITLE
fix: オーバーレイ本文右上にコピーボタンを配置

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -506,6 +506,21 @@ import { ensureShadowUiBaseStyles } from './ui/styles';
       flex-wrap: wrap;
     }
 
+    .mbu-overlay-primary-block {
+      position: relative;
+    }
+
+    .mbu-overlay-primary-block .mbu-overlay-copy {
+      position: absolute;
+      top: 2px;
+      right: 2px;
+      margin-left: 0;
+    }
+
+    .mbu-overlay-primary-block .mbu-overlay-primary-text {
+      padding-right: 44px;
+    }
+
     .mbu-overlay-status {
       font-size: 12px;
       font-weight: 750;

--- a/src/content/overlay/OverlayApp.tsx
+++ b/src/content/overlay/OverlayApp.tsx
@@ -247,32 +247,30 @@ export function OverlayApp(props: Props): React.JSX.Element | null {
         </div>
 
         <div className="mbu-overlay-body">
-          <div className="mbu-overlay-body-actions">
-            {props.viewModel.mode === 'event' ? (
-              <>
-                <button className="mbu-overlay-action" disabled={!canOpenCalendar} onClick={openCalendar} type="button">
-                  Googleカレンダーに登録
-                </button>
-                <button className="mbu-overlay-action" disabled={!canDownloadIcs} onClick={downloadIcs} type="button">
-                  .ics
-                </button>
-              </>
-            ) : null}
-            <button
-              aria-label="コピー"
-              className="mbu-overlay-action mbu-overlay-icon-button mbu-overlay-copy"
-              data-testid="overlay-copy"
-              disabled={!canCopyPrimary}
-              onClick={() => void copyPrimary()}
-              title="コピー"
-              type="button"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24">
-                <rect height="13" rx="2" width="13" x="9" y="9" />
-                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-              </svg>
-            </button>
-          </div>
+          {props.viewModel.mode === 'event' ? (
+            <div className="mbu-overlay-body-actions">
+              <button className="mbu-overlay-action" disabled={!canOpenCalendar} onClick={openCalendar} type="button">
+                Googleカレンダーに登録
+              </button>
+              <button className="mbu-overlay-action" disabled={!canDownloadIcs} onClick={downloadIcs} type="button">
+                .ics
+              </button>
+              <button
+                aria-label="コピー"
+                className="mbu-overlay-action mbu-overlay-icon-button mbu-overlay-copy"
+                data-testid="overlay-copy"
+                disabled={!canCopyPrimary}
+                onClick={() => void copyPrimary()}
+                title="コピー"
+                type="button"
+              >
+                <svg aria-hidden="true" viewBox="0 0 24 24">
+                  <rect height="13" rx="2" width="13" x="9" y="9" />
+                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                </svg>
+              </button>
+            </div>
+          ) : null}
           {isReadyEvent ? (
             <>
               <table className="mbu-overlay-event-table">
@@ -308,7 +306,23 @@ export function OverlayApp(props: Props): React.JSX.Element | null {
           ) : (
             <>
               {statusLabel ? <div className="mbu-overlay-status">{statusLabel}</div> : null}
-              <pre className="mbu-overlay-primary-text">{props.viewModel.primary}</pre>
+              <div className="mbu-overlay-primary-block">
+                <button
+                  aria-label="コピー"
+                  className="mbu-overlay-action mbu-overlay-icon-button mbu-overlay-copy"
+                  data-testid="overlay-copy"
+                  disabled={!canCopyPrimary}
+                  onClick={() => void copyPrimary()}
+                  title="コピー"
+                  type="button"
+                >
+                  <svg aria-hidden="true" viewBox="0 0 24 24">
+                    <rect height="13" rx="2" width="13" x="9" y="9" />
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                  </svg>
+                </button>
+                <pre className="mbu-overlay-primary-text">{props.viewModel.primary}</pre>
+              </div>
               {secondaryText ? <pre className="mbu-overlay-secondary-text">{secondaryText}</pre> : null}
               <AuxTextDisclosure summary="選択したテキスト（確認用）" text={selectionText} />
             </>


### PR DESCRIPTION
## 概要

要約オーバーレイのコピー操作を、本文の右上に固定（absolute）して押しやすくします。

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [x] 動作確認完了
- [x] 品質チェック通過（`mise run ci`）
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

### 変更内容

- テキストモード：本文（`primary`）ブロック右上にコピーアイコンを absolute 配置
- コピーボタンと本文が重ならないよう、本文側に右パディングを追加
- イベントモード：既存のアクション行（Googleカレンダー / .ics / コピー）は維持（レイアウト変更なし）

### 背景

現状のコピー操作が本文の近くにないため、視線移動・クリックの手数が増えていました。本文右上に常に出すことで、意図した操作を素早く行えるようにします。

### 確認観点

- テキストモードで本文右上にコピーが表示され、本文と重ならないこと
- `primary` が空/未ready時にコピーが disabled になること
- コピー成功/失敗時のトースト表示が維持されること
- イベントモードで既存のボタン配置が崩れないこと
