### PR TITLE
refactor(tests): popupテストの重複ヘルパーを共通化

### DIFF
--- a/tests/background.openai_model.test.ts
+++ b/tests/background.openai_model.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flush } from './helpers/async';
 
 type ChromeStub = {
   runtime: {
@@ -71,12 +72,6 @@ function createChromeStub(listeners: Array<(...args: unknown[]) => unknown>): Ch
   };
 }
 
-async function flush(times = 6): Promise<void> {
-  for (let i = 0; i < times; i += 1) {
-    await new Promise<void>(resolve => setTimeout(resolve, 0));
-  }
-}
-
 describe('background: OpenAI model selection', () => {
   let listeners: Array<(...args: unknown[]) => unknown>;
   let chromeStub: ChromeStub;
@@ -133,7 +128,7 @@ describe('background: OpenAI model selection', () => {
       sendResponse,
     );
 
-    await flush();
+    await flush(setTimeout, 6);
     expect(capturedModel).toBe('gpt-4o');
   });
 });

--- a/tests/content.overlay_react.test.ts
+++ b/tests/content.overlay_react.test.ts
@@ -1,5 +1,6 @@
 import { JSDOM } from 'jsdom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flush } from './helpers/async';
 
 type ContentRequest =
   | {
@@ -74,12 +75,6 @@ function createChromeStub(listeners: Array<(...args: unknown[]) => unknown>): Ch
   };
 }
 
-async function flush(window: Window, times = 6): Promise<void> {
-  for (let i = 0; i < times; i += 1) {
-    await new Promise<void>(resolve => window.setTimeout(resolve, 0));
-  }
-}
-
 async function dispatchMessage(
   listener: (...args: unknown[]) => unknown,
   request: ContentRequest,
@@ -87,7 +82,7 @@ async function dispatchMessage(
 ): Promise<void> {
   const sendResponse = vi.fn();
   listener(request, {}, sendResponse);
-  await flush(window);
+  await flush(window, 6);
 }
 
 describe('content overlay (React + Shadow DOM)', () => {
@@ -178,7 +173,7 @@ describe('content overlay (React + Shadow DOM)', () => {
     expect(copyButton).not.toBeNull();
 
     copyButton?.click();
-    await flush(dom.window);
+    await flush(dom.window, 6);
 
     expect(shadow?.textContent).toContain('コピーに失敗しました');
     expect(shadow?.querySelector('[data-testid="overlay-copy"]')).not.toBeNull();

--- a/tests/helpers/async.ts
+++ b/tests/helpers/async.ts
@@ -1,0 +1,8 @@
+export async function flush(source: Window | typeof setTimeout, times = 5): Promise<void> {
+  const setTimeoutFn: (handler: () => void, timeout?: number) => unknown =
+    typeof source === 'function' ? source : source.setTimeout.bind(source);
+
+  for (let i = 0; i < times; i += 1) {
+    await new Promise<void>(resolve => setTimeoutFn(resolve, 0));
+  }
+}

--- a/tests/helpers/forms.ts
+++ b/tests/helpers/forms.ts
@@ -1,0 +1,24 @@
+function setValue(el: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement, value: string): void {
+  const proto = Object.getPrototypeOf(el) as object;
+  const descriptor = Object.getOwnPropertyDescriptor(proto, 'value');
+  if (descriptor?.set) {
+    descriptor.set.call(el, value);
+  } else {
+    el.value = value;
+  }
+}
+
+export function inputValue(
+  window: Window,
+  el: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
+  value: string,
+): void {
+  setValue(el, value);
+  el.dispatchEvent(new window.Event('input', { bubbles: true }));
+  el.dispatchEvent(new window.Event('change', { bubbles: true }));
+}
+
+export function selectValue(window: Window, el: HTMLSelectElement, value: string): void {
+  setValue(el, value);
+  el.dispatchEvent(new window.Event('change', { bubbles: true }));
+}

--- a/tests/helpers/popupChromeStub.ts
+++ b/tests/helpers/popupChromeStub.ts
@@ -1,0 +1,85 @@
+import { vi } from 'vitest';
+
+export type PopupChromeStub = {
+  runtime: {
+    lastError: { message: string } | null;
+    sendMessage: ReturnType<typeof vi.fn>;
+  };
+  storage: {
+    sync: {
+      get: ReturnType<typeof vi.fn>;
+      set: ReturnType<typeof vi.fn>;
+    };
+    local: {
+      get: ReturnType<typeof vi.fn>;
+      set: ReturnType<typeof vi.fn>;
+      remove: ReturnType<typeof vi.fn>;
+    };
+  };
+  tabs: {
+    query: ReturnType<typeof vi.fn>;
+    sendMessage: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+};
+
+export function createPopupChromeStub(): PopupChromeStub {
+  const runtime = {
+    lastError: null as { message: string } | null,
+    sendMessage: vi.fn((_message: unknown, callback?: (resp: unknown) => void) => {
+      runtime.lastError = null;
+      callback?.({ ok: true });
+    }),
+  };
+
+  const clearError = (): void => {
+    runtime.lastError = null;
+  };
+
+  return {
+    runtime,
+    storage: {
+      sync: {
+        get: vi.fn((_keys: unknown, callback?: (items: unknown) => void) => {
+          clearError();
+          callback?.({});
+        }),
+        set: vi.fn((_items: unknown, callback?: () => void) => {
+          clearError();
+          callback?.();
+        }),
+      },
+      local: {
+        get: vi.fn((_keys: unknown, callback?: (items: unknown) => void) => {
+          clearError();
+          callback?.({});
+        }),
+        set: vi.fn((_items: unknown, callback?: () => void) => {
+          clearError();
+          callback?.();
+        }),
+        remove: vi.fn((_keys: unknown, callback?: () => void) => {
+          clearError();
+          callback?.();
+        }),
+      },
+    },
+    tabs: {
+      query: vi.fn((_queryInfo: unknown, callback?: (tabs: unknown[]) => void) => {
+        clearError();
+        callback?.([]);
+      }),
+      sendMessage: vi.fn((...args: unknown[]) => {
+        clearError();
+        const last = args.at(-1);
+        if (typeof last === 'function') {
+          (last as (resp: unknown) => void)({ ok: true });
+        }
+      }),
+      create: vi.fn((_createProperties: unknown, callback?: () => void) => {
+        clearError();
+        callback?.();
+      }),
+    },
+  };
+}

--- a/tests/helpers/popupDom.ts
+++ b/tests/helpers/popupDom.ts
@@ -1,0 +1,13 @@
+import { JSDOM } from 'jsdom';
+
+export function createPopupDom(url = 'chrome-extension://test/popup.html#pane-actions'): JSDOM {
+  const html = `<!doctype html>
+  <html lang="ja">
+    <head></head>
+    <body>
+      <div id="root"></div>
+    </body>
+  </html>`;
+
+  return new JSDOM(html, { url });
+}

--- a/tests/popup.actions_pane_event_output.test.ts
+++ b/tests/popup.actions_pane_event_output.test.ts
@@ -1,93 +1,21 @@
-import { JSDOM } from 'jsdom';
+import type { JSDOM } from 'jsdom';
 import { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flush } from './helpers/async';
+import { createPopupChromeStub, type PopupChromeStub } from './helpers/popupChromeStub';
+import { createPopupDom } from './helpers/popupDom';
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-type ChromeStub = {
-  runtime: {
-    lastError: { message: string } | null;
-    sendMessage: ReturnType<typeof vi.fn>;
-  };
-  storage: {
-    sync: {
-      get: ReturnType<typeof vi.fn>;
-      set: ReturnType<typeof vi.fn>;
-    };
-    local: {
-      get: ReturnType<typeof vi.fn>;
-      set: ReturnType<typeof vi.fn>;
-      remove: ReturnType<typeof vi.fn>;
-    };
-  };
-  tabs: {
-    query: ReturnType<typeof vi.fn>;
-    create: ReturnType<typeof vi.fn>;
-  };
-};
-
-function createPopupDom(url = 'chrome-extension://test/popup.html#pane-actions'): JSDOM {
-  const html = `<!doctype html>
-  <html lang="ja">
-    <head></head>
-    <body>
-      <div id="root"></div>
-    </body>
-  </html>`;
-
-  return new JSDOM(html, { url });
-}
-
-function createChromeStub(): ChromeStub {
-  const runtime = {
-    lastError: null as { message: string } | null,
-    sendMessage: vi.fn(),
-  };
-
-  return {
-    runtime,
-    storage: {
-      sync: {
-        get: vi.fn(),
-        set: vi.fn((_items: unknown, callback: () => void) => {
-          runtime.lastError = null;
-          callback();
-        }),
-      },
-      local: {
-        get: vi.fn(),
-        set: vi.fn((_items: unknown, callback: () => void) => {
-          runtime.lastError = null;
-          callback();
-        }),
-        remove: vi.fn((_keys: unknown, callback: () => void) => {
-          runtime.lastError = null;
-          callback();
-        }),
-      },
-    },
-    tabs: {
-      query: vi.fn(),
-      create: vi.fn(),
-    },
-  };
-}
-
-async function flush(window: Window, times = 5): Promise<void> {
-  for (let i = 0; i < times; i += 1) {
-    await new Promise<void>(resolve => window.setTimeout(resolve, 0));
-  }
-}
-
 describe('popup Actions pane: event output actions', () => {
   let dom: JSDOM;
-  let chromeStub: ChromeStub;
+  let chromeStub: PopupChromeStub;
 
   beforeEach(async () => {
     vi.resetModules();
 
     dom = createPopupDom();
-    chromeStub = createChromeStub();
+    chromeStub = createPopupChromeStub();
 
     chromeStub.storage.sync.get.mockImplementation((keys: string[], callback: (items: unknown) => void) => {
       chromeStub.runtime.lastError = null;

--- a/tests/popup.context_actions.test.ts
+++ b/tests/popup.context_actions.test.ts
@@ -1,95 +1,21 @@
-import { JSDOM } from 'jsdom';
+import type { JSDOM } from 'jsdom';
 import { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flush } from './helpers/async';
+import { createPopupChromeStub, type PopupChromeStub } from './helpers/popupChromeStub';
+import { createPopupDom } from './helpers/popupDom';
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-type ChromeStub = {
-  runtime: {
-    lastError: { message: string } | null;
-    sendMessage: ReturnType<typeof vi.fn>;
-  };
-  storage: {
-    sync: {
-      get: ReturnType<typeof vi.fn>;
-      set: ReturnType<typeof vi.fn>;
-    };
-    local: {
-      get: ReturnType<typeof vi.fn>;
-      set: ReturnType<typeof vi.fn>;
-      remove: ReturnType<typeof vi.fn>;
-    };
-  };
-  tabs: {
-    query: ReturnType<typeof vi.fn>;
-    create: ReturnType<typeof vi.fn>;
-  };
-};
-
-function createPopupDom(url = 'chrome-extension://test/popup.html#pane-actions'): JSDOM {
-  const html = `<!doctype html>
-  <html lang="ja">
-    <head></head>
-    <body>
-      <div id="root"></div>
-    </body>
-  </html>`;
-
-  return new JSDOM(html, { url });
-}
-
-function createChromeStub(overrides?: Partial<ChromeStub>): ChromeStub {
-  const runtime = {
-    lastError: null as { message: string } | null,
-    sendMessage: vi.fn(),
-  };
-
-  const chromeStub: ChromeStub = {
-    runtime,
-    storage: {
-      sync: {
-        get: vi.fn(),
-        set: vi.fn((_items: unknown, callback: () => void) => {
-          runtime.lastError = null;
-          callback();
-        }),
-      },
-      local: {
-        get: vi.fn(),
-        set: vi.fn((_items: unknown, callback: () => void) => {
-          runtime.lastError = null;
-          callback();
-        }),
-        remove: vi.fn((_keys: unknown, callback: () => void) => {
-          runtime.lastError = null;
-          callback();
-        }),
-      },
-    },
-    tabs: {
-      query: vi.fn(),
-      create: vi.fn(),
-    },
-  };
-
-  return { ...chromeStub, ...overrides };
-}
-
-async function flush(window: Window, times = 5): Promise<void> {
-  for (let i = 0; i < times; i += 1) {
-    await new Promise<void>(resolve => window.setTimeout(resolve, 0));
-  }
-}
-
 describe('popup context actions (React UI)', () => {
   let dom: JSDOM;
-  let chromeStub: ChromeStub;
+  let chromeStub: PopupChromeStub;
 
   beforeEach(async () => {
     vi.resetModules();
 
     dom = createPopupDom();
-    chromeStub = createChromeStub();
+    chromeStub = createPopupChromeStub();
 
     chromeStub.storage.sync.get.mockImplementation((keys: string[], callback: (items: unknown) => void) => {
       chromeStub.runtime.lastError = null;

--- a/tests/popup.layout.test.tsx
+++ b/tests/popup.layout.test.tsx
@@ -1,34 +1,19 @@
-import { JSDOM } from 'jsdom';
+import type { JSDOM } from 'jsdom';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PopupApp } from '../src/popup/App';
+import { flush } from './helpers/async';
+import { createPopupDom } from './helpers/popupDom';
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-
-function createPopupDom(url = 'file:///popup.html#pane-actions'): JSDOM {
-  const html = `<!doctype html>
-  <html lang="ja">
-    <body>
-      <div id="root"></div>
-    </body>
-  </html>`;
-
-  return new JSDOM(html, { url });
-}
-
-async function flush(window: Window, times = 5): Promise<void> {
-  for (let i = 0; i < times; i += 1) {
-    await new Promise<void>(resolve => window.setTimeout(resolve, 0));
-  }
-}
 
 describe('popup layout structure', () => {
   let dom: JSDOM;
 
   beforeEach(async () => {
     vi.resetModules();
-    dom = createPopupDom();
+    dom = createPopupDom('file:///popup.html#pane-actions');
     vi.stubGlobal('window', dom.window);
     vi.stubGlobal('document', dom.window.document);
     vi.stubGlobal('navigator', dom.window.navigator);

--- a/tests/popup.navigation.test.tsx
+++ b/tests/popup.navigation.test.tsx
@@ -1,27 +1,12 @@
-import { JSDOM } from 'jsdom';
+import type { JSDOM } from 'jsdom';
 import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PopupApp } from '../src/popup/App';
+import { flush } from './helpers/async';
+import { createPopupDom } from './helpers/popupDom';
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-
-function createPopupDom(url = 'chrome-extension://test/popup.html#pane-actions'): JSDOM {
-  const html = `<!doctype html>
-  <html lang="ja">
-    <body>
-      <div id="root"></div>
-    </body>
-  </html>`;
-
-  return new JSDOM(html, { url });
-}
-
-async function flush(window: Window, times = 5): Promise<void> {
-  for (let i = 0; i < times; i += 1) {
-    await new Promise<void>(resolve => window.setTimeout(resolve, 0));
-  }
-}
 
 describe('popup navigation (React + Base UI Tabs)', () => {
   let dom: JSDOM;

--- a/tests/popup.settings_pane.test.ts
+++ b/tests/popup.settings_pane.test.ts
@@ -1,104 +1,22 @@
-import { JSDOM } from 'jsdom';
+import type { JSDOM } from 'jsdom';
 import { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flush } from './helpers/async';
+import { inputValue } from './helpers/forms';
+import { createPopupChromeStub, type PopupChromeStub } from './helpers/popupChromeStub';
+import { createPopupDom } from './helpers/popupDom';
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-type ChromeStub = {
-  runtime: {
-    lastError: { message: string } | null;
-    sendMessage: ReturnType<typeof vi.fn>;
-  };
-  storage: {
-    local: {
-      get: ReturnType<typeof vi.fn>;
-      set: ReturnType<typeof vi.fn>;
-      remove: ReturnType<typeof vi.fn>;
-    };
-    sync: {
-      get: ReturnType<typeof vi.fn>;
-      set: ReturnType<typeof vi.fn>;
-    };
-  };
-  tabs: {
-    query: ReturnType<typeof vi.fn>;
-  };
-};
-
-function createPopupDom(url = 'chrome-extension://test/popup.html#pane-settings'): JSDOM {
-  const html = `<!doctype html>
-  <html lang="ja">
-    <head></head>
-    <body>
-      <div id="root"></div>
-    </body>
-  </html>`;
-
-  return new JSDOM(html, { url });
-}
-
-function createChromeStub(): ChromeStub {
-  const runtime = {
-    lastError: null as { message: string } | null,
-    sendMessage: vi.fn(),
-  };
-
-  return {
-    runtime,
-    storage: {
-      local: {
-        get: vi.fn(),
-        set: vi.fn((_items: unknown, callback: () => void) => {
-          runtime.lastError = null;
-          callback();
-        }),
-        remove: vi.fn((_keys: unknown, callback: () => void) => {
-          runtime.lastError = null;
-          callback();
-        }),
-      },
-      sync: {
-        get: vi.fn((_keys: unknown, callback: (items: unknown) => void) => callback({})),
-        set: vi.fn((_items: unknown, callback: () => void) => callback()),
-      },
-    },
-    tabs: {
-      query: vi.fn(),
-    },
-  };
-}
-
-async function flush(window: Window, times = 5): Promise<void> {
-  for (let i = 0; i < times; i += 1) {
-    await new Promise<void>(resolve => window.setTimeout(resolve, 0));
-  }
-}
-
-function inputValue(
-  window: Window,
-  el: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
-  value: string,
-): void {
-  const proto = Object.getPrototypeOf(el) as object;
-  const descriptor = Object.getOwnPropertyDescriptor(proto, 'value');
-  if (descriptor?.set) {
-    descriptor.set.call(el, value);
-  } else {
-    el.value = value;
-  }
-  el.dispatchEvent(new window.Event('input', { bubbles: true }));
-  el.dispatchEvent(new window.Event('change', { bubbles: true }));
-}
-
 describe('popup Settings pane', () => {
   let dom: JSDOM;
-  let chromeStub: ChromeStub;
+  let chromeStub: PopupChromeStub;
 
   beforeEach(async () => {
     vi.resetModules();
 
-    dom = createPopupDom();
-    chromeStub = createChromeStub();
+    dom = createPopupDom('chrome-extension://test/popup.html#pane-settings');
+    chromeStub = createPopupChromeStub();
 
     chromeStub.storage.local.get.mockImplementation((keys: string[], callback: (items: unknown) => void) => {
       chromeStub.runtime.lastError = null;

--- a/tests/popup.table_sort_pane.test.ts
+++ b/tests/popup.table_sort_pane.test.ts
@@ -1,94 +1,22 @@
-import { JSDOM } from 'jsdom';
+import type { JSDOM } from 'jsdom';
 import { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flush } from './helpers/async';
+import { inputValue } from './helpers/forms';
+import { createPopupChromeStub, type PopupChromeStub } from './helpers/popupChromeStub';
+import { createPopupDom } from './helpers/popupDom';
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-type ChromeStub = {
-  runtime: {
-    lastError: { message: string } | null;
-  };
-  storage: {
-    sync: {
-      get: ReturnType<typeof vi.fn>;
-      set: ReturnType<typeof vi.fn>;
-    };
-    local: {
-      get: ReturnType<typeof vi.fn>;
-      set: ReturnType<typeof vi.fn>;
-      remove: ReturnType<typeof vi.fn>;
-    };
-  };
-  tabs: {
-    query: ReturnType<typeof vi.fn>;
-    sendMessage: ReturnType<typeof vi.fn>;
-  };
-};
-
-function createPopupDom(url = 'chrome-extension://test/popup.html#pane-table'): JSDOM {
-  const html = `<!doctype html>
-  <html lang="ja">
-    <head></head>
-    <body>
-      <div id="root"></div>
-    </body>
-  </html>`;
-
-  return new JSDOM(html, { url });
-}
-
-function createChromeStub(): ChromeStub {
-  const runtime = { lastError: null as { message: string } | null };
-  return {
-    runtime,
-    storage: {
-      sync: {
-        get: vi.fn(),
-        set: vi.fn((_items: unknown, callback: () => void) => {
-          runtime.lastError = null;
-          callback();
-        }),
-      },
-      local: {
-        get: vi.fn((_keys: string[], callback: (items: unknown) => void) => callback({})),
-        set: vi.fn((_items: unknown, callback: () => void) => callback()),
-        remove: vi.fn((_keys: unknown, callback: () => void) => callback()),
-      },
-    },
-    tabs: {
-      query: vi.fn(),
-      sendMessage: vi.fn(),
-    },
-  };
-}
-
-async function flush(window: Window, times = 5): Promise<void> {
-  for (let i = 0; i < times; i += 1) {
-    await new Promise<void>(resolve => window.setTimeout(resolve, 0));
-  }
-}
-
-function inputValue(window: Window, el: HTMLInputElement, value: string): void {
-  const proto = Object.getPrototypeOf(el) as object;
-  const descriptor = Object.getOwnPropertyDescriptor(proto, 'value');
-  if (descriptor?.set) {
-    descriptor.set.call(el, value);
-  } else {
-    el.value = value;
-  }
-  el.dispatchEvent(new window.Event('input', { bubbles: true }));
-  el.dispatchEvent(new window.Event('change', { bubbles: true }));
-}
-
 describe('popup Table Sort pane', () => {
   let dom: JSDOM;
-  let chromeStub: ChromeStub;
+  let chromeStub: PopupChromeStub;
 
   beforeEach(async () => {
     vi.resetModules();
 
-    dom = createPopupDom();
-    chromeStub = createChromeStub();
+    dom = createPopupDom('chrome-extension://test/popup.html#pane-table');
+    chromeStub = createPopupChromeStub();
 
     chromeStub.storage.sync.get.mockImplementation((keys: string[], callback: (items: unknown) => void) => {
       chromeStub.runtime.lastError = null;


### PR DESCRIPTION
## 概要

popup系テストで重複していた `ChromeStub` / `createPopupDom` / `flush` / `inputValue` などを `tests/helpers/*` に切り出し、各テストから共通利用するようにリファクタしました。

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- なし -->

## 確認済み

- [x] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---
