### PR TITLE
fix: overlay toast placement

### DIFF
--- a/src/content/overlay/OverlayApp.tsx
+++ b/src/content/overlay/OverlayApp.tsx
@@ -200,7 +200,7 @@ export function OverlayApp(props: Props): React.JSX.Element | null {
 
   return (
     <div className="mbu-overlay-surface">
-      <ToastHost portalContainer={props.portalContainer} toastManager={toastManager} />
+      <ToastHost placement="surface" portalContainer={props.portalContainer} toastManager={toastManager} />
       <div className="mbu-overlay-panel" ref={panelRef}>
         <div className="mbu-overlay-header">
           <div className="mbu-overlay-header-left">

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -54,6 +54,14 @@ const BASE_CSS = `
   pointer-events: none;
 }
 
+.mbu-toast-viewport[data-placement='surface'] {
+  position: absolute;
+}
+
+.mbu-toast-viewport[data-placement='surface'] .mbu-toast-root {
+  max-width: min(360px, calc(100vw - 56px));
+}
+
 .mbu-toast-positioner {
   pointer-events: none;
 }

--- a/src/ui/toast.tsx
+++ b/src/ui/toast.tsx
@@ -31,13 +31,15 @@ export function createNotifications(): { toastManager: ToastManager; notify: Not
 export type ToastHostProps = {
   toastManager: ToastManager;
   portalContainer?: ToastPortalContainer;
+  placement?: 'screen' | 'surface';
 };
 
 export function ToastHost(props: ToastHostProps): React.JSX.Element {
+  const placement = props.placement ?? 'screen';
   return (
     <Toast.Provider toastManager={props.toastManager}>
       <Toast.Portal container={props.portalContainer}>
-        <Toast.Viewport className="mbu-toast-viewport">
+        <Toast.Viewport className="mbu-toast-viewport" data-placement={placement}>
           <ToastList />
         </Toast.Viewport>
       </Toast.Portal>


### PR DESCRIPTION
## 概要

Overlay（Shadow DOM）内で表示するToastの配置を見直し、ページ側のレイアウト/transform等の影響で「出る場所がおかしい」問題を避けるようにしました。

- `ToastHost` に `placement`（`screen`/`surface`）を追加
- Overlayは `placement="surface"` を使用して、オーバーレイに追従する位置へ
- Popupは従来どおり `screen`（画面固定）

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
