### PR TITLE
refactor: similarity-ts 0.8 の重複（popup/storybook・tests）を解消

### DIFF
--- a/src/popup/panes/ActionsPane.stories.tsx
+++ b/src/popup/panes/ActionsPane.stories.tsx
@@ -2,25 +2,12 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
-import type { Notifier } from '../../ui/toast';
-import type { PopupRuntime, RunContextActionRequest } from '../runtime';
+import type { RunContextActionRequest } from '../runtime';
 import { createStoryPopupRuntime } from '../storybook/createStoryPopupRuntime';
-import { ActionsPane } from './ActionsPane';
+import { ActionsPane, type ActionsPaneProps } from './ActionsPane';
 
-function ActionsPaneStory(props: {
-  runtime: PopupRuntime;
-  notify: Notifier;
-  navigateToPane: (paneId: string) => void;
-  focusTokenInput: () => void;
-}): React.JSX.Element {
-  return (
-    <ActionsPane
-      focusTokenInput={props.focusTokenInput}
-      navigateToPane={paneId => props.navigateToPane(paneId)}
-      notify={props.notify}
-      runtime={props.runtime}
-    />
-  );
+function ActionsPaneStory(props: ActionsPaneProps): React.JSX.Element {
+  return <ActionsPane {...props} />;
 }
 
 const meta = {

--- a/src/popup/panes/ActionsPane.tsx
+++ b/src/popup/panes/ActionsPane.tsx
@@ -30,7 +30,7 @@ type OutputState =
     }
   | { status: 'error'; title: string; message: string };
 
-type Props = {
+export type ActionsPaneProps = {
   runtime: PopupRuntime;
   notify: Notifier;
   navigateToPane: (paneId: PaneId) => void;
@@ -65,7 +65,7 @@ function coerceExtractedEvent(value: unknown): ExtractedEvent | null {
   return { title, start, end, allDay, location, description };
 }
 
-export function ActionsPane(props: Props): React.JSX.Element {
+export function ActionsPane(props: ActionsPaneProps): React.JSX.Element {
   const [actions, setActions] = useState<ContextAction[]>([]);
   const [output, setOutput] = useState<OutputState>({ status: 'idle' });
   const [editorId, setEditorId] = useState<string>('');

--- a/tests/helpers/chromeStub.ts
+++ b/tests/helpers/chromeStub.ts
@@ -1,0 +1,116 @@
+import { vi } from 'vitest';
+
+export type ChromeStub = {
+  runtime: {
+    lastError: { message: string } | null;
+    onInstalled: { addListener: ReturnType<typeof vi.fn> };
+    onStartup: { addListener: ReturnType<typeof vi.fn> };
+    onMessage: { addListener: ReturnType<typeof vi.fn> };
+    sendMessage: ReturnType<typeof vi.fn>;
+  };
+  storage: {
+    local: {
+      get: ReturnType<typeof vi.fn>;
+      set: ReturnType<typeof vi.fn>;
+      remove: ReturnType<typeof vi.fn>;
+    };
+    sync: {
+      get: ReturnType<typeof vi.fn>;
+      set: ReturnType<typeof vi.fn>;
+    };
+    onChanged: { addListener: ReturnType<typeof vi.fn> };
+  };
+  contextMenus: {
+    removeAll: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    onClicked: { addListener: ReturnType<typeof vi.fn> };
+  };
+  tabs: {
+    sendMessage: ReturnType<typeof vi.fn>;
+  };
+};
+
+type Options = {
+  listeners?: Array<(...args: unknown[]) => unknown>;
+  runtimeSendMessageResponse?: unknown;
+  tabsSendMessageResponse?: unknown;
+};
+
+export function createChromeStub(options: Options = {}): ChromeStub {
+  const runtimeSendMessageResponse = options.runtimeSendMessageResponse ?? { ok: true };
+  const tabsSendMessageResponse = options.tabsSendMessageResponse ?? { ok: true };
+
+  const runtime = {
+    lastError: null as { message: string } | null,
+    onInstalled: { addListener: vi.fn() },
+    onStartup: { addListener: vi.fn() },
+    onMessage: {
+      addListener: vi.fn((listener: (...args: unknown[]) => unknown) => {
+        options.listeners?.push(listener);
+      }),
+    },
+    sendMessage: vi.fn((_message: unknown, callback?: (resp: unknown) => void) => {
+      runtime.lastError = null;
+      callback?.(runtimeSendMessageResponse);
+    }),
+  };
+
+  const clearError = (): void => {
+    runtime.lastError = null;
+  };
+
+  return {
+    runtime,
+    storage: {
+      local: {
+        get: vi.fn((_keys: unknown, callback?: (items: unknown) => void) => {
+          clearError();
+          callback?.({});
+        }),
+        set: vi.fn((_items: unknown, callback?: () => void) => {
+          clearError();
+          callback?.();
+        }),
+        remove: vi.fn((_keys: unknown, callback?: () => void) => {
+          clearError();
+          callback?.();
+        }),
+      },
+      sync: {
+        get: vi.fn((_keys: unknown, callback?: (items: unknown) => void) => {
+          clearError();
+          callback?.({});
+        }),
+        set: vi.fn((_items: unknown, callback?: () => void) => {
+          clearError();
+          callback?.();
+        }),
+      },
+      onChanged: {
+        addListener: vi.fn(),
+      },
+    },
+    contextMenus: {
+      removeAll: vi.fn((callback?: () => void) => {
+        clearError();
+        callback?.();
+      }),
+      create: vi.fn((_createProperties: unknown, callback?: () => void) => {
+        clearError();
+        callback?.();
+      }),
+      onClicked: {
+        addListener: vi.fn(),
+      },
+    },
+    tabs: {
+      sendMessage: vi.fn((...args: unknown[]) => {
+        clearError();
+        const last = args.at(-1);
+        if (typeof last === 'function') {
+          (last as (resp: unknown) => void)(tabsSendMessageResponse);
+        }
+      }),
+    },
+  };
+}


### PR DESCRIPTION
## 概要

`similarity-ts -t 0.8` の結果で検出された重複（関数/型）を解消するためのリファクタです。

- **何を変更したか**
  - Storybook 用 PopupRuntime（`createStoryPopupRuntime`）の in-memory storage 実装を `createInMemoryStorageArea<T>()` に抽出して重複を削除
  - `openUrl()` に `trim()` + 空文字ガードを追加
  - テスト内で重複していた `ChromeStub` を `tests/helpers/chromeStub.ts` に集約し、複数テストから再利用
  - `ActionsPane` の props 型を `ActionsPaneProps` として export し、Storybook 側で同型を利用（構造が同じ匿名型を排除）

- **なぜ必要か**
  - `similarity-ts -t 0.8` が高い類似度の重複を検出しており、将来的な挙動のドリフトや修正漏れを防ぐために共通化しました。

- **実装上のポイント**
  - `getMessageAction()` で `message.action` の安全な取り出しを共通化
  - `tests/helpers/chromeStub.ts` は背景/コンテンツ双方で使える superset stub とし、各テストは `mockImplementation` で必要部分を上書き可能
  - `similarity-ts -t 0.8` の再実行で重複検出が解消されることを確認

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [x] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
