### PR TITLE
fix(popup): サイドバーの高さを固定してレイアウトを安定化

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -11,6 +11,8 @@
   --danger: #e57373;
   --shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
   --radius: 14px;
+  --popup-width: 800px;
+  --popup-height: 600px;
   --rail: 76px;
   --drawer: 284px;
 }
@@ -50,16 +52,36 @@ body {
 
 body.is-extension {
   margin: 0;
-  width: 800px;
+  width: var(--popup-width);
+  height: var(--popup-height);
   max-width: none;
+}
+
+.is-extension #root {
+  width: 100%;
+  height: 100%;
+}
+
+#root {
+  min-height: 0;
+}
+
+#root,
+#root > * {
+  height: 100%;
+}
+
+#root > * {
+  min-height: 0;
 }
 
 .app-shell {
   display: grid;
-  grid-template-columns: 1fr var(--rail);
+  grid-template-columns: minmax(0, 1fr) var(--rail);
   height: 100%;
   position: relative;
   overflow: hidden;
+  min-height: 0;
 }
 
 .menu-scrim {


### PR DESCRIPTION
## 概要

拡張機能ポップアップで、タブ(メニュー)切り替えのたびにサイドバーの高さが変わって見える問題を修正しました。
ポップアップのサイズを `800x600` に固定し、コンテンツは内部スクロールに統一しています。

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

- (なし)

## 確認済み

- [x] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---
