### PR TITLE
fix: toast placement (popup/overlay)

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -73,7 +73,7 @@ export function PopupApp(): React.JSX.Element {
       value={tabValue}
     >
       <div className="app-shell mbu-surface">
-        <ToastHost portalContainer={document.body} toastManager={notifications.toastManager} />
+        <ToastHost placement="surface" portalContainer={document.body} toastManager={notifications.toastManager} />
         <main className="content">
           <header className="content-header">
             <div className="title-block">

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -15,6 +15,8 @@ const BASE_CSS = `
   --mbu-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
   --mbu-focus-ring: 2px solid rgba(123, 220, 247, 0.55);
   --mbu-focus-ring-offset: 2px;
+  --mbu-toast-screen-inset: 12px 12px auto auto;
+  --mbu-toast-surface-inset: 12px 12px auto auto;
   color-scheme: dark;
 }
 
@@ -31,6 +33,8 @@ const BASE_CSS = `
   --mbu-shadow: 0 16px 44px rgba(0, 0, 0, 0.28);
   --mbu-focus-ring: 2px solid rgba(66, 133, 244, 0.65);
   --mbu-focus-ring-offset: 2px;
+  --mbu-toast-screen-inset: 12px 12px auto auto;
+  --mbu-toast-surface-inset: auto 12px 12px auto;
   color-scheme: light;
 }
 
@@ -45,8 +49,7 @@ const BASE_CSS = `
 
 .mbu-toast-viewport {
   position: fixed;
-  top: 12px;
-  right: 12px;
+  inset: var(--mbu-toast-screen-inset, 12px 12px auto auto);
   z-index: 2147483647;
   display: flex;
   flex-direction: column;
@@ -56,6 +59,7 @@ const BASE_CSS = `
 
 .mbu-toast-viewport[data-placement='surface'] {
   position: absolute;
+  inset: var(--mbu-toast-surface-inset, 12px 12px auto auto);
 }
 
 .mbu-toast-viewport[data-placement='surface'] .mbu-toast-root {
@@ -130,11 +134,9 @@ export function ensurePopupUiBaseStyles(doc: Document): void {
   const popupOverrides = doc.createElement('style');
   popupOverrides.id = POPUP_STYLE_ID;
   popupOverrides.textContent = `
-  body { position: relative; }
-  .mbu-toast-viewport {
-    position: fixed;
-    top: 12px;
-    right: 12px;
+  body {
+    position: relative;
+    --mbu-toast-surface-inset: 12px calc(var(--rail, 0px) + 12px) auto auto;
   }
   `;
   (doc.head ?? doc.documentElement).appendChild(popupOverrides);

--- a/tests/ui.styles_injection.test.ts
+++ b/tests/ui.styles_injection.test.ts
@@ -5,7 +5,7 @@ describe('UI base styles', () => {
   it('injects popup base styles once', () => {
     ensurePopupUiBaseStyles(document);
     expect(document.getElementById('mbu-ui-base-styles')).not.toBeNull();
-    expect(document.getElementById('mbu-ui-popup-overrides')?.textContent ?? '').toContain('right: 12px');
+    expect(document.getElementById('mbu-ui-popup-overrides')?.textContent ?? '').toContain('--mbu-toast-surface-inset');
 
     const before = document.querySelectorAll('#mbu-ui-base-styles').length;
     ensurePopupUiBaseStyles(document);


### PR DESCRIPTION
## 概要

- Toastの表示位置を「UIサーフェス基準」に再設計
- Popup: 右側レール（ナビ）に被らないようオフセット
- Overlay: ヘッダー操作（ピン/閉じる）に被らないよう右下に配置

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
