### PR TITLE
chore(ci): CIにactionlintとbuildジョブを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1
+        uses: rhysd/actionlint@v1.7.9
 
   lint:
     name: Lint


### PR DESCRIPTION
## 概要

lint/format/test だけでは検知しづらい「CIワークフロー自体の壊れ」や「ビルドの壊れ」を、PR時点で検知できるようにしました。

- `actionlint` ジョブを追加（GitHub Actions workflow の静的チェック。`rhysd/actionlint@v1` が存在しないため `@v1.7.9` を使用）
- `build` ジョブを追加（`pnpm build` による `tsc --noEmit` + `esbuild` の実行をCIでも担保）

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [x] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [x] 動作確認完了（CI追加に伴い、ローカルで `mise run ci` まで確認）
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
