### PR TITLE
feat: テーマ切替（自動/ダーク/ライト）を追加

### DIFF
--- a/docs/style-management.md
+++ b/docs/style-management.md
@@ -22,15 +22,17 @@ The token system is structured in 3 layers:
 
 Theme switching is done via `data-theme="dark" | "light"`.
 
+Additionally, when `data-theme` is **absent**, the UI follows the system theme via `prefers-color-scheme` (Auto).
+
 - Popup: applied to `document.documentElement`
 - ShadowRoot: applied to `shadowRoot.host`
 
 Implementation:
 
 - `src/ui/theme.ts` exports `applyTheme()` and `Theme`
-- `src/popup.ts` loads the stored theme (defaults to `dark`) and applies it at startup
-- `src/popup/panes/SettingsPane.tsx` provides a Theme selector and persists it to `chrome.storage.local`
-- `src/content.ts` applies `light` to injected ShadowRoot surfaces by default
+- `src/popup.ts` loads the stored theme (defaults to `auto`) and applies it at startup
+- `src/popup/panes/SettingsPane.tsx` provides an Auto/Dark/Light selector and persists it to `chrome.storage.local`
+- `src/content.ts` loads the stored theme (defaults to `auto`) and applies it to injected ShadowRoot surfaces
 
 ## Stylesheet Layout
 
@@ -55,4 +57,3 @@ This attaches `<link rel="stylesheet">` tags to the ShadowRoot so the overlay/to
 ## Legacy Alias Variables
 
 `src/styles/tokens/semantic.css` still exposes a small set of legacy aliases (e.g. `--bg`, `--panel`, `--text`, and `--mbu-*`) to keep incremental refactors stable while migrating older styles.
-

--- a/src/content.ts
+++ b/src/content.ts
@@ -81,10 +81,10 @@ import { createNotifications, type Notifier, ToastHost, type ToastManager } from
   }
   const globalState = globalContainer.__MBU_CONTENT_STATE__;
 
-  let currentTheme: Theme = 'dark';
+  let currentTheme: Theme = 'auto';
 
   function normalizeTheme(value: unknown): Theme {
-    return isTheme(value) ? value : 'dark';
+    return isTheme(value) ? value : 'auto';
   }
 
   function applyThemeToMounts(theme: Theme): void {
@@ -101,7 +101,7 @@ import { createNotifications, type Notifier, ToastHost, type ToastManager } from
       const data = (await storageLocalGet(['theme'])) as { theme?: unknown };
       currentTheme = normalizeTheme(data.theme);
     } catch {
-      currentTheme = 'dark';
+      currentTheme = 'auto';
     }
     applyThemeToMounts(currentTheme);
   }

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -9,16 +9,16 @@ async function initTheme(): Promise<void> {
   const runtime = createPopupRuntime();
   try {
     const { theme } = await runtime.storageLocalGet(['theme']);
-    applyTheme(isTheme(theme) ? theme : 'dark', document);
+    applyTheme(isTheme(theme) ? theme : 'auto', document);
   } catch {
-    applyTheme('dark', document);
+    applyTheme('auto', document);
   }
 }
 
 (() => {
   const start = (): void => {
     ensurePopupUiBaseStyles(document);
-    applyTheme('dark', document);
+    applyTheme('auto', document);
     void initTheme();
 
     const isExtensionPage = window.location.protocol === 'chrome-extension:';

--- a/src/popup/panes/SettingsPane.tsx
+++ b/src/popup/panes/SettingsPane.tsx
@@ -29,7 +29,7 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
   const [showToken, setShowToken] = useState(false);
   const [customPrompt, setCustomPrompt] = useState('');
   const [model, setModel] = useState(DEFAULT_OPENAI_MODEL);
-  const [theme, setTheme] = useState<Theme>('dark');
+  const [theme, setTheme] = useState<Theme>('auto');
   const tokenInputId = useId();
   const modelLabelId = useId();
   const themeLabelId = useId();
@@ -49,8 +49,8 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
         setToken(raw.openaiApiToken ?? '');
         setCustomPrompt(raw.openaiCustomPrompt ?? '');
         setModel(normalizeOpenAiModel(raw.openaiModel));
-        setTheme(isTheme(raw.theme) ? raw.theme : 'dark');
-        applyTheme(isTheme(raw.theme) ? raw.theme : 'dark', document);
+        setTheme(isTheme(raw.theme) ? raw.theme : 'auto');
+        applyTheme(isTheme(raw.theme) ? raw.theme : 'auto', document);
       } catch {
         // no-op
       }
@@ -156,8 +156,8 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
   const resetTheme = async (): Promise<void> => {
     try {
       await props.runtime.storageLocalRemove('theme');
-      setTheme('dark');
-      applyTheme('dark', document);
+      setTheme('auto');
+      applyTheme('auto', document);
       props.notify.success('デフォルトに戻しました');
     } catch {
       props.notify.error('変更に失敗しました');
@@ -324,6 +324,10 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
                 <Select.Positioner className="mbu-select-positioner" sideOffset={6}>
                   <Select.Popup className="mbu-select-popup">
                     <Select.List className="mbu-select-list">
+                      <Select.Item className="mbu-select-item" value="auto">
+                        <Select.ItemText>自動</Select.ItemText>
+                        <Select.ItemIndicator className="mbu-select-indicator">✓</Select.ItemIndicator>
+                      </Select.Item>
                       <Select.Item className="mbu-select-item" value="dark">
                         <Select.ItemText>ダーク</Select.ItemText>
                         <Select.ItemIndicator className="mbu-select-indicator">✓</Select.ItemIndicator>

--- a/src/styles/tokens/components.css
+++ b/src/styles/tokens/components.css
@@ -103,6 +103,12 @@
   color-scheme: light;
 }
 
+@media (prefers-color-scheme: light) {
+  :host:not([data-theme]) {
+    color-scheme: light;
+  }
+}
+
 :host(#my-browser-utils-toast-host) {
   top: 0;
   left: 0;

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -1,7 +1,7 @@
 :root {
   /* ========================================
    * Semantic Tokens (meaning-based)
-   * - Dark is the default when data-theme is absent
+   * - When data-theme is absent, prefers-color-scheme is used (dark fallback)
    * ====================================== */
 
   /* Layout sizing */
@@ -135,6 +135,52 @@
   --color-scrim: rgba(15, 23, 42, 0.35);
 
   color-scheme: light;
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) {
+    --color-bg: var(--primitive-color-gray-50);
+    --color-surface: var(--primitive-color-gray-50);
+    --color-surface-2: var(--primitive-color-gray-100);
+    --color-border: var(--primitive-alpha-black-12);
+    --color-border-subtle: var(--primitive-alpha-black-08);
+    --color-border-ui: var(--primitive-alpha-black-12);
+    --color-text: var(--primitive-color-gray-900);
+    --color-text-muted: rgba(17, 24, 39, 0.7);
+
+    --color-primary: var(--primitive-color-blue-500);
+    --color-primary-2: var(--primitive-color-cyan-300);
+    --color-danger: var(--primitive-color-red-600);
+
+    --shadow-elevation: var(--primitive-shadow-light);
+    --focus-ring: 2px solid rgba(66, 133, 244, 0.65);
+    --focus-ring-offset: 2px;
+    --color-scrim: rgba(15, 23, 42, 0.35);
+
+    color-scheme: light;
+  }
+
+  :host:not([data-theme]) {
+    --color-bg: var(--primitive-color-gray-50);
+    --color-surface: var(--primitive-color-gray-50);
+    --color-surface-2: var(--primitive-color-gray-100);
+    --color-border: var(--primitive-alpha-black-12);
+    --color-border-subtle: var(--primitive-alpha-black-08);
+    --color-border-ui: var(--primitive-alpha-black-12);
+    --color-text: var(--primitive-color-gray-900);
+    --color-text-muted: rgba(17, 24, 39, 0.7);
+
+    --color-primary: var(--primitive-color-blue-500);
+    --color-primary-2: var(--primitive-color-cyan-300);
+    --color-danger: var(--primitive-color-red-600);
+
+    --shadow-elevation: var(--primitive-shadow-light);
+    --focus-ring: 2px solid rgba(66, 133, 244, 0.65);
+    --focus-ring-offset: 2px;
+    --color-scrim: rgba(15, 23, 42, 0.35);
+
+    color-scheme: light;
+  }
 }
 
 :root {

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -1,11 +1,15 @@
-export type Theme = 'dark' | 'light';
+export type Theme = 'auto' | 'dark' | 'light';
 
 export function isTheme(value: unknown): value is Theme {
-  return value === 'dark' || value === 'light';
+  return value === 'auto' || value === 'dark' || value === 'light';
 }
 
 export function applyTheme(theme: Theme, target: Document | ShadowRoot): void {
   const root = target instanceof Document ? target.documentElement : target.host;
   if (!(root instanceof HTMLElement)) return;
+  if (theme === 'auto') {
+    root.removeAttribute('data-theme');
+    return;
+  }
   root.setAttribute('data-theme', theme);
 }


### PR DESCRIPTION
## 概要

設定からテーマを「自動 / ダーク / ライト」で切り替えできるようにしました。自動は `prefers-color-scheme` に追従します。

## 種別

- [x] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [x] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
