### PR TITLE
feat(popup): リンク作成（Create Link）タブ追加

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createNotifications, ToastHost } from '../ui/toast';
 import { coercePaneId, getPaneIdFromHash, type PaneId } from './panes';
 import { ActionsPane } from './panes/ActionsPane';
+import { CreateLinkPane } from './panes/CreateLinkPane';
 import { SettingsPane } from './panes/SettingsPane';
 import { TablePane } from './panes/TablePane';
 import { createPopupRuntime } from './runtime';
@@ -101,6 +102,9 @@ export function PopupApp(): React.JSX.Element {
             <Tabs.Panel data-pane="pane-table" value="pane-table">
               <TablePane notify={notifications.notify} runtime={runtime} />
             </Tabs.Panel>
+            <Tabs.Panel data-pane="pane-create-link" value="pane-create-link">
+              <CreateLinkPane notify={notifications.notify} runtime={runtime} />
+            </Tabs.Panel>
             <Tabs.Panel data-pane="pane-settings" value="pane-settings">
               <SettingsPane notify={notifications.notify} runtime={runtime} tokenInputRef={tokenInputRef} />
             </Tabs.Panel>
@@ -147,6 +151,21 @@ export function PopupApp(): React.JSX.Element {
                   </svg>
                 </span>
                 <span className="nav-label">テーブルソート</span>
+              </Tabs.Tab>
+              <Tabs.Tab
+                aria-label="リンク作成"
+                className="nav-item"
+                data-tooltip="リンク作成"
+                data-value="pane-create-link"
+                value="pane-create-link"
+              >
+                <span aria-hidden="true" className="nav-icon">
+                  <svg aria-hidden="true" viewBox="0 0 24 24">
+                    <path d="M10 13a5 5 0 0 0 7.07 0l1.41-1.41a5 5 0 0 0 0-7.07a5 5 0 0 0-7.07 0L10 5.93" />
+                    <path d="M14 11a5 5 0 0 0-7.07 0L5.52 12.41a5 5 0 0 0 0 7.07a5 5 0 0 0 7.07 0L14 18.07" />
+                  </svg>
+                </span>
+                <span className="nav-label">リンク作成</span>
               </Tabs.Tab>
               <Tabs.Tab
                 aria-label="設定"
@@ -206,6 +225,20 @@ export function PopupApp(): React.JSX.Element {
                       </svg>
                     </span>
                     テーブルソート
+                  </Button>
+                  <Button
+                    aria-current={tabValue === 'pane-create-link' ? 'page' : undefined}
+                    className={tabValue === 'pane-create-link' ? 'menu-item active' : 'menu-item'}
+                    onClick={() => navigateToPane('pane-create-link')}
+                    type="button"
+                  >
+                    <span aria-hidden="true" className="menu-icon">
+                      <svg aria-hidden="true" viewBox="0 0 24 24">
+                        <path d="M10 13a5 5 0 0 0 7.07 0l1.41-1.41a5 5 0 0 0 0-7.07a5 5 0 0 0-7.07 0L10 5.93" />
+                        <path d="M14 11a5 5 0 0 0-7.07 0L5.52 12.41a5 5 0 0 0 0 7.07a5 5 0 0 0 7.07 0L14 18.07" />
+                      </svg>
+                    </span>
+                    リンク作成
                   </Button>
                   <Button
                     aria-current={tabValue === 'pane-settings' ? 'page' : undefined}

--- a/src/popup/panes.ts
+++ b/src/popup/panes.ts
@@ -1,4 +1,4 @@
-export const PANE_IDS = ['pane-actions', 'pane-table', 'pane-settings'] as const;
+export const PANE_IDS = ['pane-actions', 'pane-table', 'pane-create-link', 'pane-settings'] as const;
 export type PaneId = (typeof PANE_IDS)[number];
 
 export function coercePaneId(value: unknown): PaneId {

--- a/src/popup/panes/CreateLinkPane.stories.tsx
+++ b/src/popup/panes/CreateLinkPane.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import { createStoryPopupRuntime } from '../storybook/createStoryPopupRuntime';
+import { CreateLinkPane } from './CreateLinkPane';
+import type { PopupPaneBaseProps } from './types';
+
+function CreateLinkPaneStory(props: PopupPaneBaseProps): React.JSX.Element {
+  return <CreateLinkPane notify={props.notify} runtime={props.runtime} />;
+}
+
+const meta = {
+  title: 'Popup/CreateLinkPane',
+  component: CreateLinkPaneStory,
+  tags: ['test'],
+  argTypes: {
+    runtime: { control: false },
+    notify: { control: false },
+  },
+} satisfies Meta<typeof CreateLinkPaneStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    runtime: createStoryPopupRuntime({
+      activeTab: { id: 1, title: 'Example', url: 'https://example.com/path?q=1' },
+    }),
+    notify: { info: fn(), success: fn(), error: fn() },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      const output = canvas.getByTestId('create-link-output') as HTMLTextAreaElement;
+      expect(output.value).toBe('[Example](<https://example.com/path?q=1>)');
+    });
+
+    await userEvent.click(canvas.getByTestId('create-link-format'));
+    await waitFor(() => {
+      expect(canvasElement.ownerDocument.querySelector('.mbu-select-popup')).toBeTruthy();
+    });
+    const popup = canvasElement.ownerDocument.querySelector<HTMLElement>('.mbu-select-popup');
+    if (!popup) throw new Error('Select popup not found');
+    await userEvent.click(within(popup).getByText('HTML <a>'));
+
+    await waitFor(() => {
+      const output = canvas.getByTestId('create-link-output') as HTMLTextAreaElement;
+      expect(output.value).toBe('<a href="https://example.com/path?q=1">Example</a>');
+    });
+  },
+};

--- a/src/popup/panes/CreateLinkPane.tsx
+++ b/src/popup/panes/CreateLinkPane.tsx
@@ -1,0 +1,173 @@
+import { Button } from '@base-ui/react/button';
+import { Input } from '@base-ui/react/input';
+import { Select } from '@base-ui/react/select';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { formatLink, LINK_FORMAT_OPTIONS, type LinkFormat } from './create_link/format';
+import type { PopupPaneBaseProps } from './types';
+
+export type CreateLinkPaneProps = PopupPaneBaseProps;
+
+export function CreateLinkPane(props: CreateLinkPaneProps): React.JSX.Element {
+  const [title, setTitle] = useState('');
+  const [url, setUrl] = useState('');
+  const [format, setFormat] = useState<LinkFormat>('markdown');
+  const [loading, setLoading] = useState(false);
+
+  const titleInputId = useId();
+  const urlInputId = useId();
+  const formatLabelId = useId();
+  const formatTriggerId = useId();
+
+  const output = useMemo(() => formatLink({ title, url }, format), [format, title, url]);
+  const canCopy = Boolean(output.trim());
+
+  const loadFromActiveTab = useCallback(
+    async ({ showToast }: { showToast: boolean }): Promise<void> => {
+      setLoading(true);
+      try {
+        const activeTab = await props.runtime.getActiveTab();
+        if (!activeTab) {
+          if (showToast) props.notify.error('有効なタブが見つかりません');
+          return;
+        }
+        setTitle(activeTab.title ?? '');
+        setUrl(activeTab.url ?? '');
+        if (showToast) props.notify.success('現在のタブから更新しました');
+      } catch (error) {
+        if (showToast) props.notify.error(error instanceof Error ? error.message : '取得に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [props.notify, props.runtime],
+  );
+
+  useEffect(() => {
+    void loadFromActiveTab({ showToast: false });
+  }, [loadFromActiveTab]);
+
+  const copyOutput = async (): Promise<void> => {
+    const text = output.trim();
+    if (!text) {
+      props.notify.error(url.trim() ? 'コピーする内容がありません' : 'URLが空です');
+      return;
+    }
+
+    try {
+      if (!navigator.clipboard?.writeText) {
+        props.notify.error('この環境ではクリップボードにコピーできません');
+        return;
+      }
+      await navigator.clipboard.writeText(text);
+      props.notify.success('コピーしました');
+    } catch {
+      props.notify.error('コピーに失敗しました');
+    }
+  };
+
+  return (
+    <div className="card card-stack">
+      <div className="row-between">
+        <h2 className="pane-title">リンク作成</h2>
+        <div className="button-row">
+          <Button
+            className="btn btn-ghost btn-small"
+            data-testid="create-link-refresh"
+            disabled={loading}
+            onClick={() => void loadFromActiveTab({ showToast: true })}
+            type="button"
+          >
+            更新
+          </Button>
+          <Button
+            className="btn btn-primary btn-small"
+            data-testid="create-link-copy"
+            disabled={!canCopy}
+            onClick={() => void copyOutput()}
+            type="button"
+          >
+            コピー
+          </Button>
+        </div>
+      </div>
+
+      <p className="hint">現在のタブのURLを各形式でコピーします（タイトル/URLは編集できます）。</p>
+
+      <div className="stack">
+        <label className="field" htmlFor={titleInputId}>
+          <span className="field-name">タイトル</span>
+          <Input
+            className="token-input"
+            data-testid="create-link-title"
+            id={titleInputId}
+            onValueChange={setTitle}
+            value={title}
+          />
+        </label>
+
+        <label className="field" htmlFor={urlInputId}>
+          <span className="field-name">URL</span>
+          <Input
+            className="token-input"
+            data-testid="create-link-url"
+            id={urlInputId}
+            onValueChange={setUrl}
+            value={url}
+          />
+        </label>
+
+        <div className="field">
+          <label className="field-name" htmlFor={formatTriggerId} id={formatLabelId}>
+            形式
+          </label>
+          <Select.Root
+            onValueChange={value => {
+              if (typeof value !== 'string') return;
+              const next = LINK_FORMAT_OPTIONS.find(option => option.value === value)?.value;
+              if (!next) return;
+              setFormat(next);
+            }}
+            value={format}
+          >
+            <Select.Trigger
+              aria-labelledby={formatLabelId}
+              className="token-input mbu-select-trigger"
+              data-testid="create-link-format"
+              id={formatTriggerId}
+              type="button"
+            >
+              <Select.Value className="mbu-select-value" />
+              <Select.Icon className="mbu-select-icon">▾</Select.Icon>
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner className="mbu-select-positioner" sideOffset={6}>
+                <Select.Popup className="mbu-select-popup">
+                  <Select.List className="mbu-select-list">
+                    {LINK_FORMAT_OPTIONS.map(option => (
+                      <Select.Item className="mbu-select-item" key={option.value} value={option.value}>
+                        <Select.ItemText>{option.label}</Select.ItemText>
+                        <Select.ItemIndicator className="mbu-select-indicator">✓</Select.ItemIndicator>
+                      </Select.Item>
+                    ))}
+                  </Select.List>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
+        </div>
+      </div>
+
+      <section className="output-panel">
+        <div className="row-between">
+          <div className="meta-title">プレビュー</div>
+        </div>
+        <textarea
+          className="summary-output summary-output--sm"
+          data-testid="create-link-output"
+          readOnly
+          value={output}
+        />
+      </section>
+    </div>
+  );
+}

--- a/src/popup/panes/create_link/format.ts
+++ b/src/popup/panes/create_link/format.ts
@@ -1,0 +1,58 @@
+export const LINK_FORMATS = ['url', 'text', 'markdown', 'html', 'org', 'bbcode'] as const;
+export type LinkFormat = (typeof LINK_FORMATS)[number];
+
+export type LinkSource = {
+  title: string;
+  url: string;
+};
+
+export const LINK_FORMAT_OPTIONS: ReadonlyArray<{ value: LinkFormat; label: string }> = [
+  { value: 'url', label: 'URL' },
+  { value: 'text', label: 'テキスト（タイトル + URL）' },
+  { value: 'markdown', label: 'Markdown' },
+  { value: 'html', label: 'HTML <a>' },
+  { value: 'org', label: 'Org-mode' },
+  { value: 'bbcode', label: 'BBCode' },
+];
+
+function escapeHtmlText(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return escapeHtmlText(value).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+function escapeMarkdownLinkText(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/\[/g, '\\[').replace(/\]/g, '\\]');
+}
+
+export function formatLink(source: LinkSource, format: LinkFormat): string {
+  const url = source.url.trim();
+  if (!url) return '';
+
+  const title = source.title.trim();
+
+  if (format === 'url') return url;
+
+  if (format === 'text') {
+    return title ? `${title}\n${url}` : url;
+  }
+
+  if (format === 'markdown') {
+    return title ? `[${escapeMarkdownLinkText(title)}](<${url}>)` : `<${url}>`;
+  }
+
+  if (format === 'html') {
+    const label = title || url;
+    return `<a href="${escapeHtmlAttribute(url)}">${escapeHtmlText(label)}</a>`;
+  }
+
+  if (format === 'org') {
+    const label = title.trim();
+    return label ? `[[${url}][${label}]]` : `[[${url}]]`;
+  }
+
+  const label = title || url;
+  return title ? `[url=${url}]${label}[/url]` : `[url]${url}[/url]`;
+}

--- a/tests/popup.create_link_format.test.ts
+++ b/tests/popup.create_link_format.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { formatLink } from '../src/popup/panes/create_link/format';
+
+describe('create link formatLink', () => {
+  it('formats markdown links', () => {
+    expect(formatLink({ title: 'Example', url: ' https://example.com ' }, 'markdown')).toBe(
+      '[Example](<https://example.com>)',
+    );
+  });
+
+  it('formats markdown autolinks when title is empty', () => {
+    expect(formatLink({ title: '', url: 'https://example.com' }, 'markdown')).toBe('<https://example.com>');
+  });
+
+  it('escapes HTML output', () => {
+    expect(formatLink({ title: 'A&B <Test> "quote"', url: 'https://example.com/?q="x"&y=1' }, 'html')).toBe(
+      '<a href="https://example.com/?q=&quot;x&quot;&amp;y=1">A&amp;B &lt;Test&gt; "quote"</a>',
+    );
+  });
+
+  it('formats org-mode links', () => {
+    expect(formatLink({ title: 'Example', url: 'https://example.com' }, 'org')).toBe(
+      '[[https://example.com][Example]]',
+    );
+    expect(formatLink({ title: '', url: 'https://example.com' }, 'org')).toBe('[[https://example.com]]');
+  });
+});

--- a/tests/popup.create_link_pane.test.ts
+++ b/tests/popup.create_link_pane.test.ts
@@ -1,0 +1,86 @@
+import type { JSDOM } from 'jsdom';
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flush } from './helpers/async';
+import { createPopupChromeStub, type PopupChromeStub } from './helpers/popupChromeStub';
+import { createPopupDom } from './helpers/popupDom';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('popup create link pane', () => {
+  let dom: JSDOM;
+  let chromeStub: PopupChromeStub;
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    dom = createPopupDom('chrome-extension://test/popup.html#pane-create-link');
+    chromeStub = createPopupChromeStub();
+
+    chromeStub.tabs.query
+      .mockImplementationOnce((_queryInfo: unknown, callback: (tabs: unknown[]) => void) => {
+        chromeStub.runtime.lastError = null;
+        callback([{ id: 1, title: 'Example Title', url: 'https://example.com/path?q=1' }]);
+      })
+      .mockImplementationOnce((_queryInfo: unknown, callback: (tabs: unknown[]) => void) => {
+        chromeStub.runtime.lastError = null;
+        callback([{ id: 1, title: 'Next Title', url: 'https://example.com/next' }]);
+      });
+
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('navigator', dom.window.navigator);
+    vi.stubGlobal('chrome', chromeStub);
+
+    Object.defineProperty(dom.window.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: vi.fn(async () => undefined),
+      },
+    });
+
+    await act(async () => {
+      await import('../src/popup.ts');
+      await flush(dom.window);
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loads active tab title/url, formats markdown, and copies to clipboard', async () => {
+    const titleInput = dom.window.document.querySelector<HTMLInputElement>('[data-testid="create-link-title"]');
+    const urlInput = dom.window.document.querySelector<HTMLInputElement>('[data-testid="create-link-url"]');
+    const output = dom.window.document.querySelector<HTMLTextAreaElement>('[data-testid="create-link-output"]');
+    expect(titleInput?.value).toBe('Example Title');
+    expect(urlInput?.value).toBe('https://example.com/path?q=1');
+    expect(output?.value).toBe('[Example Title](<https://example.com/path?q=1>)');
+
+    const copyButton = dom.window.document.querySelector<HTMLButtonElement>('[data-testid="create-link-copy"]');
+    await act(async () => {
+      copyButton?.click();
+      await flush(dom.window);
+    });
+
+    const clipboard = dom.window.navigator.clipboard as unknown as { writeText: ReturnType<typeof vi.fn> };
+    expect(clipboard.writeText).toHaveBeenCalledWith('[Example Title](<https://example.com/path?q=1>)');
+    expect(dom.window.document.body.textContent).toContain('コピーしました');
+  });
+
+  it('refreshes from active tab', async () => {
+    const refreshButton = dom.window.document.querySelector<HTMLButtonElement>('[data-testid="create-link-refresh"]');
+    await act(async () => {
+      refreshButton?.click();
+      await flush(dom.window);
+    });
+
+    const titleInput = dom.window.document.querySelector<HTMLInputElement>('[data-testid="create-link-title"]');
+    const urlInput = dom.window.document.querySelector<HTMLInputElement>('[data-testid="create-link-url"]');
+    const output = dom.window.document.querySelector<HTMLTextAreaElement>('[data-testid="create-link-output"]');
+    expect(titleInput?.value).toBe('Next Title');
+    expect(urlInput?.value).toBe('https://example.com/next');
+    expect(output?.value).toBe('[Next Title](<https://example.com/next>)');
+    expect(dom.window.document.body.textContent).toContain('現在のタブから更新しました');
+  });
+});

--- a/tests/popup.layout.test.tsx
+++ b/tests/popup.layout.test.tsx
@@ -55,7 +55,7 @@ describe('popup layout structure', () => {
     });
 
     const tabButtons = Array.from(dom.window.document.querySelectorAll<HTMLElement>('aside.sidebar [role="tab"]'));
-    expect(tabButtons.length).toBe(3);
+    expect(tabButtons.length).toBe(4);
 
     tabButtons.forEach(tab => {
       expect(tab.classList.contains('nav-item')).toBe(true);


### PR DESCRIPTION
## 概要

ポップアップに「リンク作成」タブを追加し、現在のタブURLを各形式でクリップボードへコピーできるようにしました。

- 取得: 現在タブの `title` / `url`（必要に応じて手動編集可）
- 形式: URL / テキスト（タイトル + URL） / Markdown / HTML `<a>` / Org-mode / BBCode
- 操作: 「更新」で現在タブから再取得、「コピー」でプレビュー内容をコピー

### 背景

Firefoxアドオンの Make Link のように「今見ているページのリンクを、用途に合わせた形式で素早く作りたい」ため。

### 確認観点

- タイトル/URLを編集した場合もプレビューが追従すること
- Markdown/HTML 出力で最低限のエスケープが効いていること
- URL未取得/空の場合にコピーが無効化され、適切に通知されること

### 実装メモ

- Popup runtime に現在タブ取得API（`getActiveTab`）を追加（storybook runtime も追従）
- 文字列生成は `formatLink` に集約
- タブ数変更に伴いレイアウトテストを更新

## 種別

- [x] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [x] 動作確認完了（ユニットテスト + Storybook play）
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
