### PR TITLE
refactor(ui): 設定テーマをradio化 + @/ path alias

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,8 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { StorybookConfig } from '@storybook/react-vite';
+
+const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
@@ -18,10 +22,24 @@ const config: StorybookConfig = {
         'react-dom',
         'react-dom/client',
         '@base-ui/react/button',
+        '@base-ui/react/field',
+        '@base-ui/react/form',
+        '@base-ui/react/fieldset',
         '@base-ui/react/input',
+        '@base-ui/react/radio',
+        '@base-ui/react/radio-group',
         '@base-ui/react/toast',
       ]),
     );
+
+    config.resolve ??= {};
+    const alias = config.resolve.alias;
+    const replacement = path.join(dirname, '..', 'src');
+    if (Array.isArray(alias)) {
+      alias.push({ find: '@', replacement });
+    } else {
+      config.resolve.alias = { ...(alias ?? {}), '@': replacement };
+    }
     return config;
   },
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "pnpm run clean && pnpm run typecheck && pnpm run bundle",
-    "bundle": "esbuild src/background.ts src/content.ts src/popup.ts --bundle --format=iife --platform=browser --target=es2020 --define:process.env.NODE_ENV=\\\"production\\\" --outdir=dist --sourcemap",
+    "bundle": "esbuild src/background.ts src/content.ts src/popup.ts --bundle --format=iife --platform=browser --target=es2020 --alias:@=./src --define:process.env.NODE_ENV=\\\"production\\\" --outdir=dist --sourcemap",
     "typecheck": "tsc --noEmit",
     "watch": "pnpm run bundle --watch",
     "clean": "rm -rf dist",

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -1,8 +1,8 @@
 import { Dialog, Tabs } from '@base-ui/react';
 import { Button } from '@base-ui/react/button';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Icon } from '../components/icon';
-import { createNotifications, ToastHost } from '../ui/toast';
+import { Icon } from '@/components/icon';
+import { createNotifications, ToastHost } from '@/ui/toast';
 import { coercePaneId, getPaneIdFromHash, type PaneId } from './panes';
 import { ActionsPane } from './panes/ActionsPane';
 import { CreateLinkPane } from './panes/CreateLinkPane';

--- a/src/popup/panes/SettingsPane.tsx
+++ b/src/popup/panes/SettingsPane.tsx
@@ -1,14 +1,17 @@
 import { Button } from '@base-ui/react/button';
+import { Field } from '@base-ui/react/field';
 import { Fieldset } from '@base-ui/react/fieldset';
 import { Form } from '@base-ui/react/form';
 import { Input } from '@base-ui/react/input';
+import { Radio } from '@base-ui/react/radio';
+import { RadioGroup } from '@base-ui/react/radio-group';
 import { Select } from '@base-ui/react/select';
 import { Separator } from '@base-ui/react/separator';
 import { Toggle } from '@base-ui/react/toggle';
 import { useEffect, useId, useState } from 'react';
+import { applyTheme, isTheme, type Theme } from '@/ui/theme';
 import { DEFAULT_OPENAI_MODEL, normalizeOpenAiModel, OPENAI_MODEL_OPTIONS } from '../../openai/settings';
 import type { LocalStorageData } from '../../storage/types';
-import { applyTheme, isTheme, type Theme } from '../../ui/theme';
 import type { TestOpenAiTokenRequest, TestOpenAiTokenResponse } from '../runtime';
 import type { PopupPaneBaseProps } from './types';
 
@@ -31,8 +34,6 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
   const [model, setModel] = useState(DEFAULT_OPENAI_MODEL);
   const [theme, setTheme] = useState<Theme>('auto');
   const tokenInputId = useId();
-  const modelLabelId = useId();
-  const themeLabelId = useId();
 
   useEffect(() => {
     let cancelled = false;
@@ -237,41 +238,36 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
       >
         <Fieldset.Root className="mbu-fieldset stack">
           <Fieldset.Legend className="mbu-fieldset-legend">モデル</Fieldset.Legend>
-          <div className="field">
-            <span className="field-name" id={modelLabelId}>
-              モデル
-            </span>
-            <Select.Root
-              onValueChange={value => {
-                if (typeof value === 'string') setModel(value);
-              }}
-              value={model}
+          <Select.Root
+            onValueChange={value => {
+              if (typeof value === 'string') setModel(value);
+            }}
+            value={model}
+          >
+            <Select.Trigger
+              aria-label="モデル"
+              className="token-input mbu-select-trigger"
+              data-testid="openai-model"
+              type="button"
             >
-              <Select.Trigger
-                aria-labelledby={modelLabelId}
-                className="token-input mbu-select-trigger"
-                data-testid="openai-model"
-                type="button"
-              >
-                <Select.Value className="mbu-select-value" />
-                <Select.Icon className="mbu-select-icon">▾</Select.Icon>
-              </Select.Trigger>
-              <Select.Portal>
-                <Select.Positioner className="mbu-select-positioner" sideOffset={6}>
-                  <Select.Popup className="mbu-select-popup">
-                    <Select.List className="mbu-select-list">
-                      {OPENAI_MODEL_OPTIONS.map(option => (
-                        <Select.Item className="mbu-select-item" key={option} value={option}>
-                          <Select.ItemText>{option}</Select.ItemText>
-                          <Select.ItemIndicator className="mbu-select-indicator">✓</Select.ItemIndicator>
-                        </Select.Item>
-                      ))}
-                    </Select.List>
-                  </Select.Popup>
-                </Select.Positioner>
-              </Select.Portal>
-            </Select.Root>
-          </div>
+              <Select.Value className="mbu-select-value" />
+              <Select.Icon className="mbu-select-icon">▾</Select.Icon>
+            </Select.Trigger>
+            <Select.Portal>
+              <Select.Positioner className="mbu-select-positioner" sideOffset={6}>
+                <Select.Popup className="mbu-select-popup">
+                  <Select.List className="mbu-select-list">
+                    {OPENAI_MODEL_OPTIONS.map(option => (
+                      <Select.Item className="mbu-select-item" key={option} value={option}>
+                        <Select.ItemText>{option}</Select.ItemText>
+                        <Select.ItemIndicator className="mbu-select-indicator">✓</Select.ItemIndicator>
+                      </Select.Item>
+                    ))}
+                  </Select.List>
+                </Select.Popup>
+              </Select.Positioner>
+            </Select.Portal>
+          </Select.Root>
         </Fieldset.Root>
 
         <div className="button-row">
@@ -302,47 +298,48 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
           void saveTheme();
         }}
       >
-        <Fieldset.Root className="mbu-fieldset stack">
-          <Fieldset.Legend className="mbu-fieldset-legend">テーマ</Fieldset.Legend>
-          <div className="field">
-            <span className="field-name" id={themeLabelId}>
-              テーマ
-            </span>
-            <Select.Root
-              onValueChange={value => {
-                if (!isTheme(value)) return;
-                setTheme(value);
-                applyTheme(value, document);
-              }}
-              value={theme}
-            >
-              <Select.Trigger aria-labelledby={themeLabelId} className="token-input mbu-select-trigger" type="button">
-                <Select.Value className="mbu-select-value" />
-                <Select.Icon className="mbu-select-icon">▾</Select.Icon>
-              </Select.Trigger>
-              <Select.Portal>
-                <Select.Positioner className="mbu-select-positioner" sideOffset={6}>
-                  <Select.Popup className="mbu-select-popup">
-                    <Select.List className="mbu-select-list">
-                      <Select.Item className="mbu-select-item" value="auto">
-                        <Select.ItemText>自動</Select.ItemText>
-                        <Select.ItemIndicator className="mbu-select-indicator">✓</Select.ItemIndicator>
-                      </Select.Item>
-                      <Select.Item className="mbu-select-item" value="dark">
-                        <Select.ItemText>ダーク</Select.ItemText>
-                        <Select.ItemIndicator className="mbu-select-indicator">✓</Select.ItemIndicator>
-                      </Select.Item>
-                      <Select.Item className="mbu-select-item" value="light">
-                        <Select.ItemText>ライト</Select.ItemText>
-                        <Select.ItemIndicator className="mbu-select-indicator">✓</Select.ItemIndicator>
-                      </Select.Item>
-                    </Select.List>
-                  </Select.Popup>
-                </Select.Positioner>
-              </Select.Portal>
-            </Select.Root>
-          </div>
-        </Fieldset.Root>
+        <Field.Root name="theme">
+          <Fieldset.Root
+            className="mbu-fieldset stack"
+            render={
+              <RadioGroup
+                className="mbu-radio-group"
+                onValueChange={value => {
+                  if (!isTheme(value)) return;
+                  setTheme(value);
+                  applyTheme(value, document);
+                }}
+                value={theme}
+              />
+            }
+          >
+            <Fieldset.Legend className="mbu-fieldset-legend">テーマ</Fieldset.Legend>
+            <Field.Item>
+              <Field.Label className="mbu-radio-label">
+                <Radio.Root className="mbu-radio-root" value="auto">
+                  <Radio.Indicator className="mbu-radio-indicator" />
+                </Radio.Root>
+                自動
+              </Field.Label>
+            </Field.Item>
+            <Field.Item>
+              <Field.Label className="mbu-radio-label">
+                <Radio.Root className="mbu-radio-root" value="light">
+                  <Radio.Indicator className="mbu-radio-indicator" />
+                </Radio.Root>
+                ライト
+              </Field.Label>
+            </Field.Item>
+            <Field.Item>
+              <Field.Label className="mbu-radio-label">
+                <Radio.Root className="mbu-radio-root" value="dark">
+                  <Radio.Indicator className="mbu-radio-indicator" />
+                </Radio.Root>
+                ダーク
+              </Field.Label>
+            </Field.Item>
+          </Fieldset.Root>
+        </Field.Root>
 
         <div className="button-row">
           <Button className="btn btn-primary btn-small" onClick={() => void saveTheme()} type="button">

--- a/src/styles/tokens/components.css
+++ b/src/styles/tokens/components.css
@@ -729,6 +729,58 @@ body.no-js:has(.pane:target) .pane.active:not(:target) {
   cursor: pointer;
 }
 
+.mbu-radio-group {
+  display: grid;
+  gap: 10px;
+}
+
+.mbu-radio-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-sub);
+  cursor: pointer;
+  user-select: none;
+}
+
+.mbu-radio-root {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: color-mix(in oklab, var(--color-text) 4%, transparent);
+  display: grid;
+  place-items: center;
+}
+
+.mbu-radio-root:hover {
+  background: color-mix(in oklab, var(--color-text) 6%, transparent);
+}
+
+.mbu-radio-root:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--color-primary) 60%, transparent);
+  outline-offset: 2px;
+}
+
+.mbu-radio-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--color-primary);
+  opacity: 0;
+}
+
+.mbu-radio-root[data-checked],
+.mbu-radio-root[aria-checked="true"] {
+  border-color: color-mix(in oklab, var(--color-primary) 35%, var(--line));
+  background: color-mix(in oklab, var(--color-primary) 14%, transparent);
+}
+
+.mbu-radio-root[data-checked] .mbu-radio-indicator,
+.mbu-radio-root[aria-checked="true"] .mbu-radio-indicator {
+  opacity: 1;
+}
+
 .meta-card {
   background: var(--panel-soft);
   border: 1px solid var(--line);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,10 @@
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "lib": ["ES2020", "DOM"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,11 +5,18 @@ import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
 const dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+const alias = { '@': path.join(dirname, 'src') };
 
 export default defineConfig({
+  resolve: {
+    alias,
+  },
   test: {
     projects: [
       {
+        resolve: {
+          alias,
+        },
         test: {
           name: 'unit',
           environment: 'jsdom',
@@ -18,6 +25,9 @@ export default defineConfig({
         },
       },
       {
+        resolve: {
+          alias,
+        },
         plugins: [
           storybookTest({
             configDir: path.join(dirname, '.storybook'),


### PR DESCRIPTION
## 概要

### 変更内容

- TypeScript の path alias `@/* -> src/*` を追加（`@/components/*` 形式で import 可能）
- bundler / test / Storybook でも同じ alias を解決できるように設定
  - esbuild: `--alias:@=./src`
  - Vitest: `resolve.alias`
  - Storybook(Vite): `viteFinal` で alias
- 設定画面 > テーマ（自動/ライト/ダーク）を Select → radio に変更（Base UI Forms 構成へ寄せ）
  - `Field` + `Fieldset` + `RadioGroup` + `Radio` を使用
  - `.mbu-radio-*` のスタイルを追加

### 背景

- 相対 import (`../../..`) が増えて可読性が落ちるため、`@/` を導入したい
- テーマは固定3択のため、select より radio の方が UI として適切

### 確認観点

- Popup > 設定 > テーマでラジオが表示され、選択変更で即時に見た目が切り替わる
- 「保存」「デフォルトに戻す」で storage へ保存/復帰する
- `@/` import が esbuild / vitest / storybook で解決される（`mise run ci` 実行済み）

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

- n/a

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`
