### PR TITLE
feat: 右クリックメニューからタイトルとリンクをコピー

### DIFF
--- a/tests/background.context_menu_copy_link.test.ts
+++ b/tests/background.context_menu_copy_link.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flush } from "./helpers/async";
+import { type ChromeStub, createChromeStub } from "./helpers/chromeStub";
+
+describe("background: context menu", () => {
+  let chromeStub: ChromeStub;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    chromeStub = createChromeStub();
+    vi.stubGlobal("chrome", chromeStub);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("adds copy title/link item under root menu", async () => {
+    await import("@/background.ts");
+    await flush(setTimeout, 10);
+
+    const created = chromeStub.contextMenus.create.mock.calls.map(
+      (call) => call[0] as Record<string, unknown>
+    );
+
+    expect(
+      created.some(
+        (item) =>
+          item.id === "mbu-copy-title-link" &&
+          item.parentId === "mbu-root" &&
+          item.title === "タイトルとリンクをコピー"
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要

右クリックメニュー（My Browser Utils）に「タイトルとリンクをコピー」を追加し、現在タブのタイトル+URLをクリップボードへコピーできるようにしました（失敗時はオーバーレイに表示して手動コピー可能）。

## 種別

- [x] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---
