### PR TITLE
fix: 拡張機能画面のtoast表示位置を修正

### DIFF
--- a/src/ui/toast.tsx
+++ b/src/ui/toast.tsx
@@ -1,5 +1,5 @@
 import { Toast } from "@base-ui/react/toast";
-import { useMemo } from "react";
+import { cloneElement, useMemo } from "react";
 
 export type Notifier = {
   info: (message: string) => void;
@@ -75,12 +75,8 @@ function ToastList(): React.JSX.Element {
 
   const rendered = useMemo(
     () =>
-      toasts.map((toast) => (
-        <Toast.Positioner
-          className="mbu-toast-positioner"
-          key={toast.id}
-          toast={toast}
-        >
+      toasts.map((toast) => {
+        const content = (
           <Toast.Root className="mbu-toast-root" toast={toast}>
             <Toast.Content className="mbu-toast-content">
               <div>
@@ -100,8 +96,23 @@ function ToastList(): React.JSX.Element {
               </Toast.Close>
             </Toast.Content>
           </Toast.Root>
-        </Toast.Positioner>
-      )),
+        );
+
+        if (toast.positionerProps?.anchor) {
+          return (
+            <Toast.Positioner
+              {...toast.positionerProps}
+              className="mbu-toast-positioner"
+              key={toast.id}
+              toast={toast}
+            >
+              {content}
+            </Toast.Positioner>
+          );
+        }
+
+        return cloneElement(content, { key: toast.id });
+      }),
     [toasts]
   );
 


### PR DESCRIPTION
## 概要

拡張機能のポップアップ画面でToastが右端で見切れる問題を修正しました。
未アンカーToastでも `Toast.Positioner` を使っていたため、Viewportが縮んで表示位置がずれていました。

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
