### PR TITLE
fix: 注入UIのスタイル崩れを修正

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,16 @@
   "background": {
     "service_worker": "dist/background.js"
   },
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "src/styles/tokens/primitives.css",
+        "src/styles/tokens/semantic.css",
+        "src/styles/tokens/components.css"
+      ],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],


### PR DESCRIPTION
## 概要

Content Script の注入UI（ShadowRoot のオーバーレイ/トースト）が Design Token CSS を読み込めず、ページ側のスタイルに引っ張られて見た目が崩れる問題を修正します。

背景:
- `ensureShadowUiBaseStyles` が ShadowRoot に `<link rel="stylesheet">` を挿入し、拡張機能内の `src/styles/tokens/*.css` を読み込む設計
- Manifest V3 では拡張機能リソースへの参照は `web_accessible_resources` に明示しないとブロックされるため、CSS が読み込まれていなかった

変更内容:
- `manifest.json` の `web_accessible_resources` に token CSS（primitives/semantic/components）を追加

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [ ] 動作確認完了（Chromeで拡張をリロード→任意ページで Context Action 実行→オーバーレイの余白/ボタン/フォントが適用されること、テーマ切替が効くこと）
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`) ※実行は `mise run ci` で代替
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
