### PR TITLE
chore: pnpm lintを0件に（ultracite/biome）

### DIFF
--- a/src/content/overlay/OverlayApp.stories.tsx
+++ b/src/content/overlay/OverlayApp.stories.tsx
@@ -22,7 +22,9 @@ function OverlayAppStory(props: Props): React.JSX.Element {
 
   useLayoutEffect(() => {
     const host = hostRef.current;
-    if (!host) return;
+    if (!host) {
+      return;
+    }
 
     host.id = "my-browser-utils-overlay";
     host.style.position = "fixed";
@@ -38,7 +40,9 @@ function OverlayAppStory(props: Props): React.JSX.Element {
       ? (root as HTMLDivElement)
       : document.createElement("div");
     rootEl.id = "my-browser-utils-overlay-root";
-    if (!root) shadow.appendChild(rootEl);
+    if (!root) {
+      shadow.appendChild(rootEl);
+    }
 
     setMount({ shadow, root: rootEl });
 

--- a/src/content/overlay/OverlayToastPlacement.stories.tsx
+++ b/src/content/overlay/OverlayToastPlacement.stories.tsx
@@ -13,7 +13,9 @@ function OverlayToastPlacementStory(): React.JSX.Element {
 
   useLayoutEffect(() => {
     const host = hostRef.current;
-    if (!host) return;
+    if (!host) {
+      return;
+    }
 
     host.id = "my-browser-utils-overlay";
     const shadowRoot = host.shadowRoot ?? host.attachShadow({ mode: "open" });
@@ -87,15 +89,20 @@ export const Basic: Story = {
     });
 
     const host = doc.getElementById("my-browser-utils-overlay");
-    if (!(host instanceof HTMLElement))
+    if (!(host instanceof HTMLElement)) {
       throw new Error("Overlay host not found");
+    }
     const shadow = host.shadowRoot;
-    if (!shadow) throw new Error("ShadowRoot not found");
+    if (!shadow) {
+      throw new Error("ShadowRoot not found");
+    }
 
     const trigger = shadow.querySelector<HTMLElement>(
       '[data-testid="toast-trigger"]'
     );
-    if (!trigger) throw new Error("Toast trigger not found");
+    if (!trigger) {
+      throw new Error("Toast trigger not found");
+    }
     await userEvent.click(trigger);
 
     await waitFor(() => {
@@ -103,7 +110,9 @@ export const Basic: Story = {
     });
 
     const toast = shadow.querySelector<HTMLElement>(".mbu-toast-root");
-    if (!toast) throw new Error("Toast not found");
+    if (!toast) {
+      throw new Error("Toast not found");
+    }
 
     const rect = toast.getBoundingClientRect();
     const view = doc.defaultView;

--- a/src/context_actions.ts
+++ b/src/context_actions.ts
@@ -42,23 +42,35 @@ export const DEFAULT_CONTEXT_ACTIONS: ContextAction[] = [
 ];
 
 function coerceContextAction(value: unknown): ContextAction | null {
-  if (typeof value !== "object" || value === null) return null;
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
   const raw = value as Partial<ContextAction>;
   const id = typeof raw.id === "string" ? raw.id.trim() : "";
   const title = typeof raw.title === "string" ? raw.title.trim() : "";
-  const kind =
-    raw.kind === "event" ? "event" : raw.kind === "text" ? "text" : null;
+  let kind: ContextActionKind | null = null;
+  if (raw.kind === "event") {
+    kind = "event";
+  } else if (raw.kind === "text") {
+    kind = "text";
+  }
   const prompt = typeof raw.prompt === "string" ? raw.prompt : "";
-  if (!(id && title && kind)) return null;
+  if (!(id && title && kind)) {
+    return null;
+  }
   return { id, title, kind, prompt };
 }
 
 export function normalizeContextActions(value: unknown): ContextAction[] {
-  if (!Array.isArray(value)) return [];
+  if (!Array.isArray(value)) {
+    return [];
+  }
   const actions: ContextAction[] = [];
   for (const item of value) {
     const action = coerceContextAction(item);
-    if (!action) continue;
+    if (!action) {
+      continue;
+    }
     actions.push(action);
   }
   return actions;

--- a/src/event_date_range.ts
+++ b/src/event_date_range.ts
@@ -11,61 +11,93 @@ export type EventDateRange =
   | { kind: "allDay"; startYyyyMmDd: string; endYyyyMmDdExclusive: string }
   | { kind: "dateTime"; startUtc: string; endUtc: string };
 
+function computeAllDayDateRange(params: {
+  startRaw: string;
+  endRaw: string;
+  startDateOnly: string | null;
+  endDateOnly: string | null;
+  allDay: boolean;
+}): EventDateRange | null {
+  const startDateFromTime =
+    params.allDay && !params.startDateOnly
+      ? parseDateTimeLoose(params.startRaw)
+      : null;
+  const startDate =
+    params.startDateOnly ||
+    (startDateFromTime ? formatLocalYyyyMmDdFromDate(startDateFromTime) : null);
+  if (!startDate) {
+    return null;
+  }
+
+  const endDateFromTime =
+    params.allDay && params.endRaw && !params.endDateOnly
+      ? parseDateTimeLoose(params.endRaw)
+      : null;
+  let endDate =
+    params.endDateOnly ||
+    (endDateFromTime ? formatLocalYyyyMmDdFromDate(endDateFromTime) : null) ||
+    nextDateYyyyMmDd(startDate);
+  if (endDate.length !== 8) {
+    return null;
+  }
+  if (endDate <= startDate) {
+    endDate = nextDateYyyyMmDd(startDate);
+  }
+
+  return {
+    kind: "allDay",
+    startYyyyMmDd: startDate,
+    endYyyyMmDdExclusive: endDate,
+  };
+}
+
+function computeDateTimeRange(params: {
+  startRaw: string;
+  endRaw: string;
+}): EventDateRange | null {
+  const startDate = parseDateTimeLoose(params.startRaw);
+  if (!startDate) {
+    return null;
+  }
+
+  let endDate = params.endRaw ? parseDateTimeLoose(params.endRaw) : null;
+  if (!endDate || endDate.getTime() <= startDate.getTime()) {
+    endDate = addHours(startDate, 1);
+  }
+
+  const startUtc = formatUtcDateTimeFromDate(startDate);
+  const endUtc = formatUtcDateTimeFromDate(endDate);
+  if (!(startUtc && endUtc)) {
+    return null;
+  }
+
+  return { kind: "dateTime", startUtc, endUtc };
+}
+
 export function computeEventDateRange(params: {
   start: string;
   end?: string;
   allDay?: boolean;
 }): EventDateRange | null {
   const startRaw = params.start.trim();
-  if (!startRaw) return null;
+  if (!startRaw) {
+    return null;
+  }
   const endRaw = params.end?.trim() ?? "";
 
   const startDateOnly = parseDateOnlyToYyyyMmDd(startRaw);
   const endDateOnly = endRaw ? parseDateOnlyToYyyyMmDd(endRaw) : null;
 
-  if (params.allDay === true || startDateOnly) {
-    const startDateFromTime =
-      params.allDay === true && !startDateOnly
-        ? parseDateTimeLoose(startRaw)
-        : null;
-    const startDate =
-      startDateOnly ||
-      (startDateFromTime
-        ? formatLocalYyyyMmDdFromDate(startDateFromTime)
-        : null);
-    if (!startDate) return null;
-
-    const endDateFromTime =
-      params.allDay === true && endRaw && !endDateOnly
-        ? parseDateTimeLoose(endRaw)
-        : null;
-    let endDate =
-      endDateOnly ||
-      (endDateFromTime ? formatLocalYyyyMmDdFromDate(endDateFromTime) : null) ||
-      nextDateYyyyMmDd(startDate);
-    if (endDate.length !== 8) return null;
-    if (endDate <= startDate) {
-      endDate = nextDateYyyyMmDd(startDate);
-    }
-
-    return {
-      kind: "allDay",
-      startYyyyMmDd: startDate,
-      endYyyyMmDdExclusive: endDate,
-    };
+  const shouldTreatAsAllDay = params.allDay === true || Boolean(startDateOnly);
+  if (shouldTreatAsAllDay) {
+    return computeAllDayDateRange({
+      startRaw,
+      endRaw,
+      startDateOnly,
+      endDateOnly,
+      allDay: params.allDay === true,
+    });
   }
 
-  const startDate = parseDateTimeLoose(startRaw);
-  if (!startDate) return null;
-
-  let endDate = endRaw ? parseDateTimeLoose(endRaw) : null;
-  if (!endDate || endDate.getTime() <= startDate.getTime()) {
-    endDate = addHours(startDate, 1);
-  }
-
-  const startUtc = formatUtcDateTimeFromDate(startDate);
-  const endUtc = endDate ? formatUtcDateTimeFromDate(endDate) : null;
-  if (!(startUtc && endUtc)) return null;
-
-  return { kind: "dateTime", startUtc, endUtc };
+  return computeDateTimeRange({ startRaw, endRaw });
 }

--- a/src/ics.ts
+++ b/src/ics.ts
@@ -22,7 +22,9 @@ export function buildIcs(event: ExtractedEvent): string | null {
 
   const foldLine = (line: string): string => {
     const max = 75;
-    if (line.length <= max) return line;
+    if (line.length <= max) {
+      return line;
+    }
     let out = "";
     for (let i = 0; i < line.length; i += max) {
       out += (i === 0 ? "" : "\r\n ") + line.slice(i, i + max);
@@ -35,7 +37,9 @@ export function buildIcs(event: ExtractedEvent): string | null {
     end: event.end,
     allDay: event.allDay,
   });
-  if (!range) return null;
+  if (!range) {
+    return null;
+  }
 
   const dtStartLine =
     range.kind === "allDay"
@@ -51,7 +55,9 @@ export function buildIcs(event: ExtractedEvent): string | null {
       ? crypto.randomUUID()
       : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const dtStamp = formatUtcDateTimeFromDate(new Date());
-  if (!dtStamp) return null;
+  if (!dtStamp) {
+    return null;
+  }
 
   const lines = [
     "BEGIN:VCALENDAR",
@@ -70,5 +76,5 @@ export function buildIcs(event: ExtractedEvent): string | null {
     "END:VCALENDAR",
   ].filter(Boolean);
 
-  return lines.map(foldLine).join("\r\n") + "\r\n";
+  return `${lines.map(foldLine).join("\r\n")}\r\n`;
 }

--- a/src/openai/settings.ts
+++ b/src/openai/settings.ts
@@ -14,7 +14,9 @@ export type OpenAiSettings = {
 };
 
 export function normalizeOpenAiModel(value: unknown): string {
-  if (typeof value !== "string") return DEFAULT_OPENAI_MODEL;
+  if (typeof value !== "string") {
+    return DEFAULT_OPENAI_MODEL;
+  }
   const model = value.trim();
   return model || DEFAULT_OPENAI_MODEL;
 }

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -19,7 +19,9 @@ async function initTheme(): Promise<void> {
   const start = (): void => {
     ensurePopupUiBaseStyles(document);
     applyTheme("auto", document);
-    void initTheme();
+    initTheme().catch(() => {
+      // no-op
+    });
 
     const isExtensionPage = window.location.protocol === "chrome-extension:";
     if (isExtensionPage) {

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -12,7 +12,9 @@ import { createNotifications, ToastHost } from "@/ui/toast";
 
 function replaceHash(nextHash: string): void {
   try {
-    if (window.location.hash === nextHash) return;
+    if (window.location.hash === nextHash) {
+      return;
+    }
     window.history.replaceState(null, "", nextHash);
   } catch {
     window.location.hash = nextHash;
@@ -48,7 +50,9 @@ export function PopupApp(): React.JSX.Element {
 
   const syncFromHash = useCallback(() => {
     const next = getPaneIdFromHash(window.location.hash);
-    if (!next) return;
+    if (!next) {
+      return;
+    }
     setTabValue(next);
   }, []);
 

--- a/src/popup/navigation.ts
+++ b/src/popup/navigation.ts
@@ -18,6 +18,9 @@ type NavigationElements = {
   menuClose: HTMLButtonElement | null;
 };
 
+// Regex patterns at module level for performance (lint/performance/useTopLevelRegex)
+const HASH_PREFIX_REGEX = /^#/;
+
 function getElements(document: Document): NavigationElements {
   return {
     body: document.body,
@@ -44,7 +47,9 @@ function updateHero(
   activeTargetId?: string
 ): void {
   const { heroChip, ctaPill } = elements;
-  if (!(heroChip && ctaPill)) return;
+  if (!(heroChip && ctaPill)) {
+    return;
+  }
 
   ctaPill.textContent = "";
   ctaPill.hidden = true;
@@ -64,27 +69,33 @@ function resolveTargetId(
   elements: NavigationElements,
   targetId?: string
 ): string | undefined {
-  if (targetId) return targetId;
+  if (targetId) {
+    return targetId;
+  }
   const fromActive = elements.navItems.find((item) =>
     item.classList.contains("active")
   )?.dataset.target;
-  if (fromActive) return fromActive;
+  if (fromActive) {
+    return fromActive;
+  }
   return elements.panes[0]?.id;
 }
 
 function setActive(elements: NavigationElements, targetId?: string): void {
   const resolvedTargetId = resolveTargetId(elements, targetId);
-  if (!resolvedTargetId) return;
+  if (!resolvedTargetId) {
+    return;
+  }
 
-  elements.navItems.forEach((nav) => {
+  for (const nav of elements.navItems) {
     const isActive = nav.dataset.target === resolvedTargetId;
     nav.classList.toggle("active", isActive);
     nav.setAttribute("aria-selected", isActive ? "true" : "false");
-  });
+  }
 
-  elements.panes.forEach((pane) => {
+  for (const pane of elements.panes) {
     pane.classList.toggle("active", pane.id === resolvedTargetId);
-  });
+  }
 
   updateHero(elements, resolvedTargetId);
 
@@ -98,15 +109,21 @@ function getTargetFromHash(
   document: Document,
   window: Window
 ): string | undefined {
-  const hash = window.location.hash.replace(/^#/, "");
-  if (!hash) return;
-  if (!document.getElementById(hash)) return;
+  const hash = window.location.hash.replace(HASH_PREFIX_REGEX, "");
+  if (!hash) {
+    return;
+  }
+  if (!document.getElementById(hash)) {
+    return;
+  }
   return hash;
 }
 
 function safelyReplaceHash(window: Window, nextHash: string): void {
   try {
-    if (window.location.hash === nextHash) return;
+    if (window.location.hash === nextHash) {
+      return;
+    }
     window.history.replaceState(null, "", nextHash);
   } catch {
     window.location.hash = nextHash;
@@ -161,8 +178,12 @@ function moveFocusOutOfMenuIfNeeded(
 ): void {
   // aria-hidden を付与する前にフォーカスを外へ退避させる（警告回避）
   const active = env.document.activeElement;
-  if (!(active instanceof HTMLElement)) return;
-  if (!elements.menuDrawer?.contains(active)) return;
+  if (!(active instanceof HTMLElement)) {
+    return;
+  }
+  if (!elements.menuDrawer?.contains(active)) {
+    return;
+  }
 
   const body = elements.body;
   const prevTabIndex = body.getAttribute("tabindex");
@@ -202,7 +223,9 @@ function setupMenuDrawer(
   let lastActiveElement: HTMLElement | null = null;
 
   const openMenu = (): void => {
-    if (isMenuOpen(elements)) return;
+    if (isMenuOpen(elements)) {
+      return;
+    }
     lastActiveElement =
       env.document.activeElement instanceof HTMLElement
         ? env.document.activeElement
@@ -212,7 +235,9 @@ function setupMenuDrawer(
   };
 
   const closeMenu = (): void => {
-    if (!isMenuOpen(elements)) return;
+    if (!isMenuOpen(elements)) {
+      return;
+    }
     moveFocusOutOfMenuIfNeeded(env, elements);
     applyMenuOpenState(elements, false);
     restoreFocusAfterCloseSoon(env, elements, lastActiveElement);
@@ -239,16 +264,22 @@ function setupMenuDrawer(
   });
 
   env.window.addEventListener("keydown", (event) => {
-    if (event.key !== "Escape") return;
+    if (event.key !== "Escape") {
+      return;
+    }
     closeMenu();
   });
 
   // ドロワー内のメニュー選択後は閉じる
   elements.menuDrawer?.addEventListener("click", (event) => {
     const target = event.target as HTMLElement | null;
-    if (!target) return;
+    if (!target) {
+      return;
+    }
     const menuItem = target.closest<HTMLElement>("[data-target]");
-    if (!menuItem) return;
+    if (!menuItem) {
+      return;
+    }
     closeMenu();
   });
 
@@ -268,7 +299,7 @@ function setupTabs(
   elements: NavigationElements,
   menu: MenuDrawerApi
 ): void {
-  elements.navItems.forEach((item) => {
+  for (const item of elements.navItems) {
     item.addEventListener("click", (event) => {
       // ドロワー内/外どちらからでも、タブ切り替え時はメニューを閉じる
       menu.closeMenu();
@@ -284,12 +315,14 @@ function setupTabs(
       event.preventDefault();
 
       const targetId = item.dataset.target;
-      if (!targetId) return;
+      if (!targetId) {
+        return;
+      }
 
       setActive(elements, targetId);
       safelyReplaceHash(env.window, `#${targetId}`);
     });
-  });
+  }
 
   env.window.addEventListener("hashchange", () => {
     menu.closeMenu();

--- a/src/popup/panes.ts
+++ b/src/popup/panes.ts
@@ -6,6 +6,8 @@ export const PANE_IDS = [
 ] as const;
 export type PaneId = (typeof PANE_IDS)[number];
 
+const HASH_PREFIX_REGEX = /^#/;
+
 export function coercePaneId(value: unknown): PaneId {
   return PANE_IDS.includes(value as PaneId)
     ? (value as PaneId)
@@ -13,6 +15,6 @@ export function coercePaneId(value: unknown): PaneId {
 }
 
 export function getPaneIdFromHash(hash: string): PaneId | null {
-  const value = hash.replace(/^#/, "");
+  const value = hash.replace(HASH_PREFIX_REGEX, "");
   return PANE_IDS.includes(value as PaneId) ? (value as PaneId) : null;
 }

--- a/src/popup/panes/SettingsPane.tsx
+++ b/src/popup/panes/SettingsPane.tsx
@@ -29,10 +29,16 @@ export type SettingsPaneProps = PopupPaneBaseProps & {
 function isTestOpenAiTokenResponse(
   value: unknown
 ): value is TestOpenAiTokenResponse {
-  if (typeof value !== "object" || value === null) return false;
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
   const v = value as { ok?: unknown };
-  if (typeof v.ok !== "boolean") return false;
-  if (v.ok) return true;
+  if (typeof v.ok !== "boolean") {
+    return false;
+  }
+  if (v.ok) {
+    return true;
+  }
   return typeof (value as { error?: unknown }).error === "string";
 }
 
@@ -46,7 +52,7 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
 
   useEffect(() => {
     let cancelled = false;
-    void (async () => {
+    (async () => {
       try {
         const data = await props.runtime.storageLocalGet([
           "openaiApiToken",
@@ -55,7 +61,9 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
           "theme",
         ]);
         const raw = data as Partial<LocalStorageData>;
-        if (cancelled) return;
+        if (cancelled) {
+          return;
+        }
         setToken(raw.openaiApiToken ?? "");
         setCustomPrompt(raw.openaiCustomPrompt ?? "");
         setModel(normalizeOpenAiModel(raw.openaiModel));
@@ -64,7 +72,9 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
       } catch {
         // no-op
       }
-    })();
+    })().catch(() => {
+      // no-op
+    });
     return () => {
       cancelled = true;
     };
@@ -159,7 +169,9 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
   };
 
   const saveTheme = async (): Promise<void> => {
-    if (!isTheme(theme)) return;
+    if (!isTheme(theme)) {
+      return;
+    }
     try {
       await props.runtime.storageLocalSet({ theme });
       props.notify.success("保存しました");
@@ -189,7 +201,9 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
       <Form
         className="stack"
         onFormSubmit={() => {
-          void saveToken();
+          saveToken().catch(() => {
+            // no-op
+          });
         }}
       >
         <Fieldset.Root className="mbu-fieldset stack">
@@ -225,7 +239,11 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
           <Button
             className="btn btn-primary btn-small"
             data-testid="token-save"
-            onClick={() => void saveToken()}
+            onClick={() => {
+              saveToken().catch(() => {
+                // no-op
+              });
+            }}
             type="button"
           >
             保存
@@ -233,7 +251,11 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
           <Button
             className="btn-delete"
             data-testid="token-clear"
-            onClick={() => void clearToken()}
+            onClick={() => {
+              clearToken().catch(() => {
+                // no-op
+              });
+            }}
             type="button"
           >
             削除
@@ -241,7 +263,11 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
           <Button
             className="btn btn-ghost btn-small"
             data-testid="token-test"
-            onClick={() => void testToken()}
+            onClick={() => {
+              testToken().catch(() => {
+                // no-op
+              });
+            }}
             type="button"
           >
             トークン確認
@@ -254,7 +280,9 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
       <Form
         className="stack"
         onFormSubmit={() => {
-          void saveModel();
+          saveModel().catch(() => {
+            // no-op
+          });
         }}
       >
         <Fieldset.Root className="mbu-fieldset stack">
@@ -263,7 +291,9 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
           </Fieldset.Legend>
           <Select.Root
             onValueChange={(value) => {
-              if (typeof value === "string") setModel(value);
+              if (typeof value === "string") {
+                setModel(value);
+              }
             }}
             value={model}
           >
@@ -306,7 +336,11 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
           <Button
             className="btn btn-primary btn-small"
             data-testid="model-save"
-            onClick={() => void saveModel()}
+            onClick={() => {
+              saveModel().catch(() => {
+                // no-op
+              });
+            }}
             type="button"
           >
             保存
@@ -314,7 +348,11 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
           <Button
             className="btn btn-ghost btn-small"
             data-testid="model-reset"
-            onClick={() => void resetModel()}
+            onClick={() => {
+              resetModel().catch(() => {
+                // no-op
+              });
+            }}
             type="button"
           >
             デフォルトに戻す
@@ -327,7 +365,9 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
       <Form
         className="stack"
         onFormSubmit={() => {
-          void saveTheme();
+          saveTheme().catch(() => {
+            // no-op
+          });
         }}
       >
         <Field.Root name="theme">
@@ -337,7 +377,9 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
               <RadioGroup
                 className="mbu-radio-group"
                 onValueChange={(value) => {
-                  if (!isTheme(value)) return;
+                  if (!isTheme(value)) {
+                    return;
+                  }
                   setTheme(value);
                   applyTheme(value, document);
                 }}
@@ -378,14 +420,22 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
         <div className="button-row">
           <Button
             className="btn btn-primary btn-small"
-            onClick={() => void saveTheme()}
+            onClick={() => {
+              saveTheme().catch(() => {
+                // no-op
+              });
+            }}
             type="button"
           >
             保存
           </Button>
           <Button
             className="btn btn-ghost btn-small"
-            onClick={() => void resetTheme()}
+            onClick={() => {
+              resetTheme().catch(() => {
+                // no-op
+              });
+            }}
             type="button"
           >
             デフォルトに戻す
@@ -398,7 +448,9 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
       <Form
         className="stack"
         onFormSubmit={() => {
-          void savePrompt();
+          savePrompt().catch(() => {
+            // no-op
+          });
         }}
       >
         <Fieldset.Root className="mbu-fieldset stack">
@@ -421,7 +473,11 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
           <Button
             className="btn btn-primary btn-small"
             data-testid="prompt-save"
-            onClick={() => void savePrompt()}
+            onClick={() => {
+              savePrompt().catch(() => {
+                // no-op
+              });
+            }}
             type="button"
           >
             保存
@@ -429,7 +485,11 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
           <Button
             className="btn-delete"
             data-testid="prompt-clear"
-            onClick={() => void clearPrompt()}
+            onClick={() => {
+              clearPrompt().catch(() => {
+                // no-op
+              });
+            }}
             type="button"
           >
             削除

--- a/src/popup/panes/TablePane.tsx
+++ b/src/popup/panes/TablePane.tsx
@@ -10,7 +10,9 @@ import type { EnableTableSortMessage } from "@/popup/runtime";
 export type TablePaneProps = PopupPaneBaseProps;
 
 function normalizePatterns(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
+  if (!Array.isArray(value)) {
+    return [];
+  }
   return value
     .map((item) => (typeof item === "string" ? item.trim() : ""))
     .filter(Boolean)
@@ -24,7 +26,7 @@ export function TablePane(props: TablePaneProps): React.JSX.Element {
 
   useEffect(() => {
     let cancelled = false;
-    void (async () => {
+    (async () => {
       try {
         const data = await props.runtime.storageSyncGet([
           "domainPatterns",
@@ -37,7 +39,9 @@ export function TablePane(props: TablePaneProps): React.JSX.Element {
       } catch {
         // no-op
       }
-    })();
+    })().catch(() => {
+      // no-op
+    });
     return () => {
       cancelled = true;
     };
@@ -119,7 +123,11 @@ export function TablePane(props: TablePaneProps): React.JSX.Element {
         <Button
           className="btn btn-primary"
           data-testid="enable-table-sort"
-          onClick={() => void enableNow()}
+          onClick={() => {
+            enableNow().catch(() => {
+              // no-op
+            });
+          }}
           type="button"
         >
           このタブで有効化
@@ -129,7 +137,11 @@ export function TablePane(props: TablePaneProps): React.JSX.Element {
       <Toggle
         className="mbu-toggle-inline"
         data-testid="auto-enable-sort"
-        onPressedChange={(pressed) => void toggleAutoEnable(pressed)}
+        onPressedChange={(pressed) => {
+          toggleAutoEnable(pressed).catch(() => {
+            // no-op
+          });
+        }}
         pressed={autoEnable}
         type="button"
       >
@@ -143,7 +155,9 @@ export function TablePane(props: TablePaneProps): React.JSX.Element {
         <Form
           className="pattern-input-group"
           onFormSubmit={() => {
-            void addPattern();
+            addPattern().catch(() => {
+              // no-op
+            });
           }}
         >
           <Input
@@ -157,7 +171,11 @@ export function TablePane(props: TablePaneProps): React.JSX.Element {
           <Button
             className="btn btn-ghost btn-small"
             data-testid="pattern-add"
-            onClick={() => void addPattern()}
+            onClick={() => {
+              addPattern().catch(() => {
+                // no-op
+              });
+            }}
             type="button"
           >
             追加
@@ -179,7 +197,9 @@ export function TablePane(props: TablePaneProps): React.JSX.Element {
                         className="btn-delete"
                         data-pattern-remove={pattern}
                         onClick={() => {
-                          void removePattern(pattern);
+                          removePattern(pattern).catch(() => {
+                            // no-op
+                          });
                         }}
                         type="button"
                       >

--- a/src/popup/panes/create_link/format.ts
+++ b/src/popup/panes/create_link/format.ts
@@ -45,11 +45,15 @@ function escapeMarkdownLinkText(value: string): string {
 
 export function formatLink(source: LinkSource, format: LinkFormat): string {
   const url = source.url.trim();
-  if (!url) return "";
+  if (!url) {
+    return "";
+  }
 
   const title = source.title.trim();
 
-  if (format === "url") return url;
+  if (format === "url") {
+    return url;
+  }
 
   if (format === "text") {
     return title ? `${title}\n${url}` : url;

--- a/src/popup/runtime.ts
+++ b/src/popup/runtime.ts
@@ -74,7 +74,7 @@ function fallbackStorageGet(
   keys: string[]
 ): Record<string, unknown> {
   const data: Record<string, unknown> = {};
-  keys.forEach((key) => {
+  for (const key of keys) {
     let raw: string | null = null;
     try {
       raw = window.localStorage.getItem(
@@ -83,13 +83,15 @@ function fallbackStorageGet(
     } catch {
       raw = null;
     }
-    if (raw === null) return;
+    if (raw === null) {
+      continue;
+    }
     try {
       data[key] = JSON.parse(raw) as unknown;
     } catch {
       data[key] = raw;
     }
-  });
+  }
   return data;
 }
 
@@ -97,7 +99,7 @@ function fallbackStorageSet(
   scope: "sync" | "local",
   items: Record<string, unknown>
 ): void {
-  Object.entries(items).forEach(([key, value]) => {
+  for (const [key, value] of Object.entries(items)) {
     try {
       window.localStorage.setItem(
         `${FALLBACK_STORAGE_PREFIX}${scope}:${key}`,
@@ -106,7 +108,7 @@ function fallbackStorageSet(
     } catch {
       // no-op
     }
-  });
+  }
 }
 
 function fallbackStorageRemove(
@@ -114,7 +116,7 @@ function fallbackStorageRemove(
   keys: string[] | string
 ): void {
   const list = Array.isArray(keys) ? keys : [keys];
-  list.forEach((key) => {
+  for (const key of list) {
     try {
       window.localStorage.removeItem(
         `${FALLBACK_STORAGE_PREFIX}${scope}:${key}`
@@ -122,7 +124,7 @@ function fallbackStorageRemove(
     } catch {
       // no-op
     }
-  });
+  }
 }
 
 export function createPopupRuntime(): PopupRuntime {
@@ -251,7 +253,9 @@ export function createPopupRuntime(): PopupRuntime {
     });
     const [tab] = tabs;
     const id = tab?.id;
-    if (id === undefined) return null;
+    if (id === undefined) {
+      return null;
+    }
     return { id, title: tab?.title, url: tab?.url };
   };
 
@@ -306,9 +310,11 @@ export function createPopupRuntime(): PopupRuntime {
 
   const openUrl: PopupRuntime["openUrl"] = (url) => {
     const trimmed = url.trim();
-    if (!trimmed) return;
+    if (!trimmed) {
+      return;
+    }
     if (isExtensionPage && (chrome as unknown as { tabs?: unknown }).tabs) {
-      void chrome.tabs.create({ url: trimmed });
+      chrome.tabs.create({ url: trimmed });
       return;
     }
     window.open(trimmed, "_blank", "noopener,noreferrer");

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -18,7 +18,9 @@ function resolveStyleHref(path: string): string {
     const runtime = (
       chrome as unknown as { runtime?: { getURL?: (input: string) => string } }
     ).runtime;
-    if (runtime?.getURL) return runtime.getURL(path);
+    if (runtime?.getURL) {
+      return runtime.getURL(path);
+    }
   } catch {
     // non-extension contexts (tests/storybook)
   }
@@ -30,7 +32,9 @@ function ensureDocumentStylesheet(
   id: string,
   path: string
 ): void {
-  if (doc.getElementById(id)) return;
+  if (doc.getElementById(id)) {
+    return;
+  }
   const link = doc.createElement("link");
   link.id = id;
   link.rel = "stylesheet";
@@ -43,7 +47,9 @@ function ensureShadowStylesheet(
   id: string,
   path: string
 ): void {
-  if (shadowRoot.querySelector(`#${id}`)) return;
+  if (shadowRoot.querySelector(`#${id}`)) {
+    return;
+  }
   const link = shadowRoot.ownerDocument.createElement("link");
   link.id = id;
   link.rel = "stylesheet";

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -7,7 +7,9 @@ export function isTheme(value: unknown): value is Theme {
 export function applyTheme(theme: Theme, target: Document | ShadowRoot): void {
   const root =
     target instanceof Document ? target.documentElement : target.host;
-  if (!(root instanceof HTMLElement)) return;
+  if (!(root instanceof HTMLElement)) {
+    return;
+  }
   if (theme === "auto") {
     root.removeAttribute("data-theme");
     return;

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -9,12 +9,16 @@ export function safeParseJsonObject<T>(
     catch: () => "parse-error" as const,
   });
 
-  if (Result.isSuccess(direct)) return direct;
+  if (Result.isSuccess(direct)) {
+    return direct;
+  }
 
   const trimmed = text.trim();
   const start = trimmed.indexOf("{");
   const end = trimmed.lastIndexOf("}");
-  if (start === -1 || end === -1 || end <= start) return direct;
+  if (start === -1 || end === -1 || end <= start) {
+    return direct;
+  }
 
   return Result.try({
     immediate: true,

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -2,12 +2,18 @@ import { Result } from "@praha/byethrow";
 import { toErrorMessage } from "@/utils/errors";
 
 export function extractChatCompletionText(json: unknown): string | null {
-  if (typeof json !== "object" || json === null) return null;
+  if (typeof json !== "object" || json === null) {
+    return null;
+  }
   const choices = (json as { choices?: unknown }).choices;
-  if (!Array.isArray(choices) || choices.length === 0) return null;
+  if (!Array.isArray(choices) || choices.length === 0) {
+    return null;
+  }
   const first = choices[0] as { message?: { content?: unknown } };
   const content = first?.message?.content;
-  if (typeof content !== "string") return null;
+  if (typeof content !== "string") {
+    return null;
+  }
   return content.trim();
 }
 

--- a/tests/background.context_menu_copy_link.test.ts
+++ b/tests/background.context_menu_copy_link.test.ts
@@ -5,7 +5,7 @@ import { type ChromeStub, createChromeStub } from "./helpers/chromeStub";
 describe("background: context menu", () => {
   let chromeStub: ChromeStub;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.resetModules();
     chromeStub = createChromeStub();
     vi.stubGlobal("chrome", chromeStub);

--- a/tests/content.overlay_react.test.ts
+++ b/tests/content.overlay_react.test.ts
@@ -47,7 +47,7 @@ describe("content overlay (React + Shadow DOM)", () => {
   let listeners: Array<(...args: unknown[]) => unknown>;
   let chromeStub: ChromeStub;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.resetModules();
     (
       globalThis as unknown as { __MBU_CONTENT_STATE__?: unknown }
@@ -62,7 +62,7 @@ describe("content overlay (React + Shadow DOM)", () => {
     Object.defineProperty(dom.window.navigator, "clipboard", {
       configurable: true,
       value: {
-        writeText: vi.fn(async () => undefined),
+        writeText: vi.fn(() => Promise.resolve(undefined)),
       },
     });
 
@@ -112,7 +112,9 @@ describe("content overlay (React + Shadow DOM)", () => {
   it("shows an error toast in the shadow root when clipboard write fails", async () => {
     await import("@/content.ts");
     const [listener] = listeners;
-    if (!listener) throw new Error("missing message listener");
+    if (!listener) {
+      throw new Error("missing message listener");
+    }
 
     const clipboard = dom.window.navigator.clipboard as unknown as {
       writeText: ReturnType<typeof vi.fn>;
@@ -158,7 +160,9 @@ describe("content overlay (React + Shadow DOM)", () => {
   it("hides the copy button while overlay is loading", async () => {
     await import("@/content.ts");
     const [listener] = listeners;
-    if (!listener) throw new Error("missing message listener");
+    if (!listener) {
+      throw new Error("missing message listener");
+    }
 
     await dispatchMessage(
       listener,
@@ -185,7 +189,9 @@ describe("content overlay (React + Shadow DOM)", () => {
   it("does not duplicate the source label in summary overlay titles", async () => {
     await import("@/content.ts");
     const [listener] = listeners;
-    if (!listener) throw new Error("missing message listener");
+    if (!listener) {
+      throw new Error("missing message listener");
+    }
 
     await dispatchMessage(
       listener,
@@ -213,7 +219,9 @@ describe("content overlay (React + Shadow DOM)", () => {
   it("renders event overlay with table + quote, hides link-copy, and keeps pin next to close", async () => {
     await import("@/content.ts");
     const [listener] = listeners;
-    if (!listener) throw new Error("missing message listener");
+    if (!listener) {
+      throw new Error("missing message listener");
+    }
 
     await dispatchMessage(
       listener,
@@ -298,7 +306,9 @@ describe("content overlay (React + Shadow DOM)", () => {
   it("renders selection text as an auxiliary collapsed section in text mode", async () => {
     await import("@/content.ts");
     const [listener] = listeners;
-    if (!listener) throw new Error("missing message listener");
+    if (!listener) {
+      throw new Error("missing message listener");
+    }
 
     await dispatchMessage(
       listener,

--- a/tests/date_utils.test.ts
+++ b/tests/date_utils.test.ts
@@ -7,13 +7,15 @@ import {
   parseDateTimeLoose,
 } from "@/date_utils";
 
+const YYYYMMDD_REGEX = /^\d{8}$/;
+
 describe("src/date_utils.ts", () => {
   it("parses date-only inputs to YYYYMMDD", () => {
     expect(parseDateOnlyToYyyyMmDd("2025-1-2")).toBe("20250102");
     expect(parseDateOnlyToYyyyMmDd("2025/01/02")).toBe("20250102");
     expect(parseDateOnlyToYyyyMmDd("2025年1月2日")).toBe("20250102");
     expect(parseDateOnlyToYyyyMmDd("2025-02-30")).toBeNull();
-    expect(parseDateOnlyToYyyyMmDd("12/16")).toMatch(/^\d{8}$/);
+    expect(parseDateOnlyToYyyyMmDd("12/16")).toMatch(YYYYMMDD_REGEX);
   });
 
   it("parses ISO-ish datetime with timezone offsets", () => {

--- a/tests/helpers/forms.ts
+++ b/tests/helpers/forms.ts
@@ -41,12 +41,16 @@ export async function selectBaseUiOption(
   await flush(window);
 
   const popup = window.document.querySelector<HTMLElement>(".mbu-select-popup");
-  if (!popup) throw new Error("Select popup not found");
+  if (!popup) {
+    throw new Error("Select popup not found");
+  }
 
   const option = Array.from(
     popup.querySelectorAll<HTMLElement>(".mbu-select-item")
   ).find((item) => item.textContent?.includes(optionText));
-  if (!option) throw new Error(`Select option not found: ${optionText}`);
+  if (!option) {
+    throw new Error(`Select option not found: ${optionText}`);
+  }
 
   // Base UI Select commits selection only when the item is highlighted for mouse interactions.
   option.dispatchEvent(new window.MouseEvent("mousemove", { bubbles: true }));

--- a/tests/popup.layout.test.tsx
+++ b/tests/popup.layout.test.tsx
@@ -13,7 +13,7 @@ import { createPopupDom } from "./helpers/popupDom";
 describe("popup layout structure", () => {
   let dom: JSDOM;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.resetModules();
     dom = createPopupDom("file:///popup.html#pane-actions");
     vi.stubGlobal("window", dom.window);
@@ -27,7 +27,9 @@ describe("popup layout structure", () => {
 
   it("renders the hero logo column before the title text (prevents narrow title wrapping)", async () => {
     const rootEl = dom.window.document.getElementById("root");
-    if (!rootEl) throw new Error("missing #root");
+    if (!rootEl) {
+      throw new Error("missing #root");
+    }
 
     const root = createRoot(rootEl);
     await act(async () => {
@@ -42,14 +44,16 @@ describe("popup layout structure", () => {
     expect(children[0]?.classList.contains("hero-logo-wrap")).toBe(true);
     expect(children[1]?.classList.contains("title-text")).toBe(true);
 
-    await act(async () => {
+    act(() => {
       root.unmount();
     });
   });
 
   it("styles sidebar tabs using the nav-item structure (icon + label)", async () => {
     const rootEl = dom.window.document.getElementById("root");
-    if (!rootEl) throw new Error("missing #root");
+    if (!rootEl) {
+      throw new Error("missing #root");
+    }
 
     const root = createRoot(rootEl);
     await act(async () => {
@@ -64,13 +68,13 @@ describe("popup layout structure", () => {
     );
     expect(tabButtons.length).toBe(4);
 
-    tabButtons.forEach((tab) => {
+    for (const tab of tabButtons) {
       expect(tab.classList.contains("nav-item")).toBe(true);
       expect(tab.querySelector(".nav-icon")).not.toBeNull();
       expect(tab.querySelector(".nav-label")).not.toBeNull();
-    });
+    }
 
-    await act(async () => {
+    act(() => {
       root.unmount();
     });
   });

--- a/tests/popup.navigation.test.tsx
+++ b/tests/popup.navigation.test.tsx
@@ -13,7 +13,7 @@ import { createPopupDom } from "./helpers/popupDom";
 describe("popup navigation (React + Base UI Tabs)", () => {
   let dom: JSDOM;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.resetModules();
 
     dom = createPopupDom("chrome-extension://test/popup.html#pane-settings");
@@ -28,7 +28,9 @@ describe("popup navigation (React + Base UI Tabs)", () => {
 
   it("derives initial tab from location.hash", async () => {
     const rootEl = dom.window.document.getElementById("root");
-    if (!rootEl) throw new Error("missing #root");
+    if (!rootEl) {
+      throw new Error("missing #root");
+    }
 
     const root = createRoot(rootEl);
     await act(async () => {
@@ -44,14 +46,16 @@ describe("popup navigation (React + Base UI Tabs)", () => {
       dom.window.document.querySelector('[data-pane="pane-actions"]')
     ).toBeNull();
 
-    await act(async () => {
+    act(() => {
       root.unmount();
     });
   });
 
   it("switches tabs and synchronizes hash", async () => {
     const rootEl = dom.window.document.getElementById("root");
-    if (!rootEl) throw new Error("missing #root");
+    if (!rootEl) {
+      throw new Error("missing #root");
+    }
 
     const root = createRoot(rootEl);
     await act(async () => {
@@ -72,14 +76,16 @@ describe("popup navigation (React + Base UI Tabs)", () => {
       dom.window.document.querySelector('[data-pane="pane-table"]')
     ).not.toBeNull();
 
-    await act(async () => {
+    act(() => {
       root.unmount();
     });
   });
 
   it("opens and closes the menu drawer (scrim + Escape)", async () => {
     const rootEl = dom.window.document.getElementById("root");
-    if (!rootEl) throw new Error("missing #root");
+    if (!rootEl) {
+      throw new Error("missing #root");
+    }
 
     const root = createRoot(rootEl);
     await act(async () => {
@@ -124,7 +130,7 @@ describe("popup navigation (React + Base UI Tabs)", () => {
     });
     expect(dom.window.document.querySelector('[role="dialog"]')).toBeNull();
 
-    await act(async () => {
+    act(() => {
       root.unmount();
     });
   });

--- a/tests/popup.settings_pane.test.ts
+++ b/tests/popup.settings_pane.test.ts
@@ -28,11 +28,15 @@ describe("popup Settings pane", () => {
         chromeStub.runtime.lastError = null;
         const keyList = Array.isArray(keys) ? keys : [String(keys)];
         const items: Record<string, unknown> = {};
-        if (keyList.includes("openaiApiToken"))
+        if (keyList.includes("openaiApiToken")) {
           items.openaiApiToken = "sk-existing";
-        if (keyList.includes("openaiCustomPrompt"))
+        }
+        if (keyList.includes("openaiCustomPrompt")) {
           items.openaiCustomPrompt = "prompt";
-        if (keyList.includes("openaiModel")) items.openaiModel = "gpt-4o";
+        }
+        if (keyList.includes("openaiModel")) {
+          items.openaiModel = "gpt-4o";
+        }
         callback(items);
       }
     );

--- a/tests/popup.table_sort_pane.test.ts
+++ b/tests/popup.table_sort_pane.test.ts
@@ -28,9 +28,12 @@ describe("popup Table Sort pane", () => {
         chromeStub.runtime.lastError = null;
         const keyList = Array.isArray(keys) ? keys : [String(keys)];
         const items: Record<string, unknown> = {};
-        if (keyList.includes("domainPatterns"))
+        if (keyList.includes("domainPatterns")) {
           items.domainPatterns = ["example.com/foo*"];
-        if (keyList.includes("autoEnableSort")) items.autoEnableSort = false;
+        }
+        if (keyList.includes("autoEnableSort")) {
+          items.autoEnableSort = false;
+        }
         callback(items);
       }
     );

--- a/tests/popup.token_guard.test.ts
+++ b/tests/popup.token_guard.test.ts
@@ -4,7 +4,9 @@ import { ensureOpenAiTokenConfigured } from "@/popup/token_guard";
 
 describe("ensureOpenAiTokenConfigured", () => {
   it("returns Success when token exists", async () => {
-    const storageLocalGet = vi.fn(async () => ({ openaiApiToken: "sk-test" }));
+    const storageLocalGet = vi.fn(() =>
+      Promise.resolve({ openaiApiToken: "sk-test" })
+    );
     const showNotification = vi.fn();
     const navigateToPane = vi.fn();
     const focusTokenInput = vi.fn();
@@ -23,7 +25,9 @@ describe("ensureOpenAiTokenConfigured", () => {
   });
 
   it("navigates to settings and focuses when token missing", async () => {
-    const storageLocalGet = vi.fn(async () => ({ openaiApiToken: "" }));
+    const storageLocalGet = vi.fn(() =>
+      Promise.resolve({ openaiApiToken: "" })
+    );
     const showNotification = vi.fn();
     const navigateToPane = vi.fn();
     const focusTokenInput = vi.fn();
@@ -48,9 +52,9 @@ describe("ensureOpenAiTokenConfigured", () => {
   });
 
   it("treats storage errors as missing token", async () => {
-    const storageLocalGet = vi.fn(async () => {
-      throw new Error("storage failed");
-    });
+    const storageLocalGet = vi.fn(() =>
+      Promise.reject(new Error("storage failed"))
+    );
     const showNotification = vi.fn();
     const navigateToPane = vi.fn();
     const focusTokenInput = vi.fn();

--- a/tests/ui.toast_host.test.tsx
+++ b/tests/ui.toast_host.test.tsx
@@ -41,7 +41,7 @@ describe("ToastHost", () => {
       document.body.querySelector(".mbu-toast-root")?.textContent
     ).toContain("完了しました");
 
-    await act(async () => {
+    act(() => {
       root.unmount();
     });
     container.remove();
@@ -74,7 +74,7 @@ describe("ToastHost", () => {
     );
     expect(document.body.querySelector(".mbu-toast-root")).toBeNull();
 
-    await act(async () => {
+    act(() => {
       root.unmount();
     });
     host.remove();

--- a/tests/utils.openai.test.ts
+++ b/tests/utils.openai.test.ts
@@ -42,13 +42,13 @@ describe("extractOpenAiApiErrorMessage", () => {
 
 describe("fetchOpenAiChatCompletionText", () => {
   it("returns Success when response has content", async () => {
-    const fetchFn = vi.fn(
-      async () =>
-        ({
-          ok: true,
-          status: 200,
-          json: async () => ({ choices: [{ message: { content: "ok" } }] }),
-        }) as unknown as Response
+    const fetchFn = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ choices: [{ message: { content: "ok" } }] }),
+      } as unknown as Response)
     );
 
     const result = await fetchOpenAiChatCompletionText(
@@ -65,13 +65,12 @@ describe("fetchOpenAiChatCompletionText", () => {
   });
 
   it("returns Failure when content is missing", async () => {
-    const fetchFn = vi.fn(
-      async () =>
-        ({
-          ok: true,
-          status: 200,
-          json: async () => ({ choices: [{ message: {} }] }),
-        }) as unknown as Response
+    const fetchFn = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ choices: [{ message: {} }] }),
+      } as unknown as Response)
     );
 
     const result = await fetchOpenAiChatCompletionText(
@@ -87,13 +86,12 @@ describe("fetchOpenAiChatCompletionText", () => {
   });
 
   it("returns Failure with API message when response not ok", async () => {
-    const fetchFn = vi.fn(
-      async () =>
-        ({
-          ok: false,
-          status: 401,
-          json: async () => ({ error: { message: "invalid token" } }),
-        }) as unknown as Response
+    const fetchFn = vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error: { message: "invalid token" } }),
+      } as unknown as Response)
     );
 
     const result = await fetchOpenAiChatCompletionText(
@@ -109,15 +107,12 @@ describe("fetchOpenAiChatCompletionText", () => {
   });
 
   it("returns Failure with status when response JSON is not available", async () => {
-    const fetchFn = vi.fn(
-      async () =>
-        ({
-          ok: false,
-          status: 503,
-          json: async () => {
-            throw new Error("boom");
-          },
-        }) as unknown as Response
+    const fetchFn = vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 503,
+        json: () => Promise.reject(new Error("boom")),
+      } as unknown as Response)
     );
 
     const result = await fetchOpenAiChatCompletionText(
@@ -133,9 +128,7 @@ describe("fetchOpenAiChatCompletionText", () => {
   });
 
   it("returns Failure when fetch throws", async () => {
-    const fetchFn = vi.fn(async () => {
-      throw new Error("network");
-    });
+    const fetchFn = vi.fn(() => Promise.reject(new Error("network")));
 
     const result = await fetchOpenAiChatCompletionText(
       fetchFn as unknown as typeof fetch,
@@ -152,13 +145,12 @@ describe("fetchOpenAiChatCompletionText", () => {
 
 describe("fetchOpenAiChatCompletionOk", () => {
   it("returns Success on ok response", async () => {
-    const fetchFn = vi.fn(
-      async () =>
-        ({
-          ok: true,
-          status: 200,
-          json: async () => ({}),
-        }) as unknown as Response
+    const fetchFn = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+      } as unknown as Response)
     );
 
     const result = await fetchOpenAiChatCompletionOk(
@@ -170,13 +162,12 @@ describe("fetchOpenAiChatCompletionOk", () => {
   });
 
   it("returns Failure on non-ok response", async () => {
-    const fetchFn = vi.fn(
-      async () =>
-        ({
-          ok: false,
-          status: 400,
-          json: async () => ({ error: { message: "bad request" } }),
-        }) as unknown as Response
+    const fetchFn = vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve({ error: { message: "bad request" } }),
+      } as unknown as Response)
     );
 
     const result = await fetchOpenAiChatCompletionOk(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ES2020",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
## 概要

### 背景

- `pnpm lint`（ultracite/biome）が多数の指摘で失敗しており、品質ゲート（`mise run ci`）も通らない状態でした
- 併せて TypeScript の `lib` 設定が不足しており、DOMの反復（`NodeList` の `for...of` 等）や `Array.prototype.at` の型解決で `tsc` が失敗していました

### 変更内容

- `pnpm lint`（ultracite/biome）の指摘を全解消（format含む）
- overlay / popup / background を中心に、lintルール対応に伴う整理・分割で可読性を改善
  - `void` の排除（`.catch` で明示的に握り潰し）
  - `forEach` の置換（`for...of` 等）
  - 正規表現のトップレベル化
  - 過度な認知的複雑度の解消（関数/コンポーネント分割）
- 右クリックメニュー「タイトルとリンクをコピー」周りの処理を lint 観点で整理（挙動は維持）
  - handler をヘルパー関数へ分割して複雑度を低減
  - content 側の `copyToClipboard` 応答を `noVoid`/`useAwait` に沿って整理
- `tsconfig.json` の `lib` を `ES2022` + `DOM.Iterable` に更新し、typecheck/build を安定化
- テストのmock/`act()`周りの不要な `async` を整理（`useAwait` 対応）

### 確認観点（レビュー時）

- lint対応のリファクタにより、挙動の変更が入っていないこと
  - overlay / popup の表示・操作
  - 右クリックメニュー「タイトルとリンクをコピー」の動作
- `tsconfig.json` の `lib` 変更が、意図しない型定義差分を増やしていないこと

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [x] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- なし -->

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過（`mise run ci`）
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
