### PR TITLE
chore: スタイル未適用を検知するテストを追加

### DIFF
--- a/src/content/overlay/OverlayApp.stories.tsx
+++ b/src/content/overlay/OverlayApp.stories.tsx
@@ -140,3 +140,58 @@ export const Ready: Story = {
     });
   },
 };
+
+export const ReadyStylesApplied: Story = {
+  args: {
+    viewModel: {
+      open: true,
+      status: "ready",
+      mode: "text",
+      source: "selection",
+      title: "要約",
+      primary: "要約結果（storybook）",
+      secondary: "選択範囲:\n引用テキスト",
+      anchorRect: null,
+    },
+  },
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      const host = canvasElement.querySelector<HTMLDivElement>(
+        "#my-browser-utils-overlay"
+      );
+      const shadow = host?.shadowRoot ?? null;
+      expect(host).toBeTruthy();
+      expect(shadow).toBeTruthy();
+      expect(shadow?.querySelector(".mbu-overlay-panel")).toBeTruthy();
+    });
+
+    const host = canvasElement.querySelector<HTMLDivElement>(
+      "#my-browser-utils-overlay"
+    );
+    const shadow = host?.shadowRoot ?? null;
+    const panel = shadow?.querySelector<HTMLElement>(".mbu-overlay-panel");
+
+    if (!(host && shadow && panel)) {
+      throw new Error("overlay host/shadow/panel not mounted");
+    }
+
+    await waitFor(() => {
+      expect(
+        getComputedStyle(host).getPropertyValue("--primitive-space-7").trim()
+      ).toBe("16px");
+    });
+
+    await waitFor(() => {
+      expect(
+        getComputedStyle(host).getPropertyValue("--mbu-surface").trim()
+      ).not.toBe("");
+    });
+
+    await waitFor(() => {
+      const styles = getComputedStyle(panel);
+      expect(styles.display).toBe("grid");
+      expect(styles.borderTopStyle).toBe("solid");
+      expect(styles.borderTopWidth).toBe("1px");
+    });
+  },
+};

--- a/tests/ui.styles_assets.test.ts
+++ b/tests/ui.styles_assets.test.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const dirname =
+  typeof __dirname !== "undefined"
+    ? __dirname
+    : path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.join(dirname, "..");
+
+type WebAccessibleEntry = { resources?: string[] };
+type Manifest = { web_accessible_resources?: WebAccessibleEntry[] };
+
+const SHADOW_UI_STYLESHEETS = [
+  "src/styles/tokens/primitives.css",
+  "src/styles/tokens/semantic.css",
+  "src/styles/tokens/components.css",
+] as const;
+
+const POPUP_UI_STYLESHEETS = [
+  "src/styles/base.css",
+  "src/styles/layout.css",
+  "src/styles/utilities.css",
+] as const;
+
+describe("UI styles wiring", () => {
+  it("lists ShadowRoot styles as web_accessible_resources", () => {
+    const manifestPath = path.join(projectRoot, "manifest.json");
+    const manifest = JSON.parse(
+      fs.readFileSync(manifestPath, "utf8")
+    ) as Manifest;
+
+    const resources = new Set(
+      (manifest.web_accessible_resources ?? []).flatMap(
+        (entry) => entry.resources ?? []
+      )
+    );
+
+    for (const cssPath of SHADOW_UI_STYLESHEETS) {
+      expect(resources).toContain(cssPath);
+    }
+  });
+
+  it("keeps stylesheet assets present on disk", () => {
+    for (const cssPath of [...SHADOW_UI_STYLESHEETS, ...POPUP_UI_STYLESHEETS]) {
+      expect(fs.existsSync(path.join(projectRoot, cssPath))).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## 概要

スタイルが適切に当たっていない状態を早期に検知できるよう、UIスタイルの回帰テストを追加しました。

- Overlay(ShadowRoot)でトークンCSS/コンポーネントCSSが実際に適用されていることをStorybook(Playwright)で検証
- `manifest.json` の `web_accessible_resources` とCSSアセットの存在をVitestで検証

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [x] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
