### PR TITLE
fix: テーマ設定のデフォルトボタンを削除

### DIFF
--- a/src/popup/panes/SettingsPane.tsx
+++ b/src/popup/panes/SettingsPane.tsx
@@ -187,17 +187,6 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
     props.notify.error("保存に失敗しました");
   };
 
-  const resetTheme = async (): Promise<void> => {
-    const removed = await props.runtime.storageLocalRemove("theme");
-    if (Result.isSuccess(removed)) {
-      setTheme("auto");
-      applyTheme("auto", document);
-      props.notify.success("デフォルトに戻しました");
-      return;
-    }
-    props.notify.error("変更に失敗しました");
-  };
-
   return (
     <div className="card card-stack">
       <div className="stack-sm">
@@ -435,17 +424,6 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
             type="button"
           >
             保存
-          </Button>
-          <Button
-            className="btn btn-ghost btn-small"
-            onClick={() => {
-              resetTheme().catch(() => {
-                // no-op
-              });
-            }}
-            type="button"
-          >
-            デフォルトに戻す
           </Button>
         </div>
       </Form>


### PR DESCRIPTION
## 概要

テーマ設定の「デフォルトに戻す」ボタンを削除しました（「自動」を選んで保存で十分なため）。

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
