### PR TITLE
test(storybook): AuxTextDisclosure の Story を追加

### DIFF
--- a/src/components/AuxTextDisclosure.stories.tsx
+++ b/src/components/AuxTextDisclosure.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, userEvent, waitFor, within } from "storybook/test";
+import { AuxTextDisclosure } from "./AuxTextDisclosure";
+
+type Props = React.ComponentProps<typeof AuxTextDisclosure>;
+
+function AuxTextDisclosureStory(props: Props): React.JSX.Element | null {
+  return <AuxTextDisclosure {...props} />;
+}
+
+const meta = {
+  title: "Components/AuxTextDisclosure",
+  component: AuxTextDisclosureStory,
+  tags: ["test"],
+} satisfies Meta<typeof AuxTextDisclosureStory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ClosedByDefault: Story = {
+  args: {
+    summary: "選択範囲",
+    text: "  引用テキスト  ",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const details = canvasElement.querySelector<HTMLDetailsElement>(
+      "details.mbu-overlay-aux"
+    );
+    expect(details).toBeTruthy();
+    if (!details) {
+      return;
+    }
+    expect(details.open).toBe(false);
+
+    const summaryEl = canvas.getByText("選択範囲");
+
+    await userEvent.click(summaryEl);
+    await waitFor(() => {
+      expect(details.open).toBe(true);
+    });
+
+    const quote =
+      canvasElement.querySelector<HTMLElement>(".mbu-overlay-quote");
+    expect(quote?.textContent).toBe("引用テキスト");
+
+    await userEvent.click(summaryEl);
+    await waitFor(() => {
+      expect(details.open).toBe(false);
+    });
+  },
+};
+
+export const OpenByDefault: Story = {
+  args: {
+    summary: "選択範囲",
+    text: "引用テキスト",
+    defaultOpen: true,
+  },
+  play: ({ canvasElement }) => {
+    const details = canvasElement.querySelector<HTMLDetailsElement>(
+      "details.mbu-overlay-aux"
+    );
+    expect(details?.open).toBe(true);
+  },
+};
+
+export const EmptyText: Story = {
+  args: {
+    summary: "選択範囲",
+    text: "   ",
+  },
+  play: ({ canvasElement }) => {
+    expect(canvasElement.querySelector("details.mbu-overlay-aux")).toBeNull();
+  },
+};


### PR DESCRIPTION
## 概要

- `AuxTextDisclosure` の Story を追加し、Storybook 上で挙動を単体確認できるようにしました。
- 開閉トグル、`defaultOpen`、空文字入力時に `null` を返す挙動を play で検証します。

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

- なし

## 確認済み

- [x] 動作確認完了（Storybook smoke / Storybook tests）
- [x] 品質チェック通過（`mise run ci`）
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

### レビューポイント

- Story が `Components/AuxTextDisclosure` として追加されていること
- `ClosedByDefault` の play で開閉と trim が確認できること
- `EmptyText` の play で `details` がレンダリングされないこと
