### PR TITLE
fix(ui): toastインジケータの位置ずれを修正

### DIFF
--- a/src/styles/tokens/components.css
+++ b/src/styles/tokens/components.css
@@ -224,7 +224,8 @@
 }
 
 .mbu-toast-root[data-has-description="true"] .mbu-toast-indicator {
-  margin-top: 3px;
+  margin-top: 0;
+  align-self: center;
 }
 
 .mbu-toast-text {


### PR DESCRIPTION
## 概要

Toast（「コピーに失敗しました」など説明文付き）の左側インジケータ（点）が上にずれて見える問題を修正しました。

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 背景 / 変更内容

- 説明文付きToastではコンテンツが `align-items: flex-start` となるため、インジケータも上寄せになっていました。
- インジケータのみ中央寄せになるように調整し、タイトル行の中央付近に揃うようにしました。

## 確認観点

- 説明文なし/ありのToastで、インジケータが不自然にずれないこと
- 各type（info/success/error）で表示が崩れないこと

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [x] 動作確認完了（Storybook: UI/Toast）
- [x] 品質チェック通過（`mise run ci`）
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
