### PR TITLE
fix(overlay): Storybookで右端見切れする表示位置を調整

### DIFF
--- a/src/content/overlay/OverlayApp.tsx
+++ b/src/content/overlay/OverlayApp.tsx
@@ -168,7 +168,7 @@ function positionOverlayHost(params: {
   const anchor = params.anchorRect;
   if (!anchor) {
     updateHostPosition(params.host, size, {
-      left: window.innerWidth - size.width - 16,
+      left: window.innerWidth - size.width - 40,
       top: 16,
     });
     return;

--- a/src/content/overlay/OverlayToastPlacement.stories.tsx
+++ b/src/content/overlay/OverlayToastPlacement.stories.tsx
@@ -23,7 +23,7 @@ function OverlayToastPlacementStory(): React.JSX.Element {
     applyTheme("dark", shadowRoot);
 
     host.style.left = "auto";
-    host.style.right = "16px";
+    host.style.right = "40px";
     host.style.top = "16px";
     setShadow(shadowRoot);
   }, []);


### PR DESCRIPTION
## 概要

StorybookのOverlayApp/OverlayToastPlacementのfixtureで、右端に寄りすぎてボックスシャドウ等が画面外にクリップされていたため、表示位置を内側に調整しました。

- anchorRectなし（デフォルト表示）時のOverlay位置を右端から40px内側に変更
- OverlayToastPlacement fixtureも右端オフセットを40pxに揃えて、見切れを回避
- 選択範囲(anchorRectあり)に追従する通常表示は変更なし

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- なし -->

## 確認済み

- [x] 動作確認完了（Storybook表示）
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
