### PR TITLE
fix(storybook): テーマ切替ツールバー追加とIcon Galleryの配色トークン化

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,7 +1,23 @@
 import type { Preview } from "@storybook/react-vite";
 import { ensurePopupUiBaseStyles } from "@/ui/styles";
+import { applyTheme, isTheme } from "@/ui/theme";
 
 const preview: Preview = {
+  globalTypes: {
+    theme: {
+      description: "UI theme",
+      defaultValue: "auto",
+      toolbar: {
+        icon: "circlehollow",
+        items: [
+          { value: "auto", title: "Auto" },
+          { value: "dark", title: "Dark" },
+          { value: "light", title: "Light" },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
   parameters: {
     controls: {
       matchers: {
@@ -17,9 +33,11 @@ const preview: Preview = {
     },
   },
   decorators: [
-    (Story) => {
+    (Story, context) => {
       ensurePopupUiBaseStyles(document);
       document.body.classList.add("is-extension");
+      const theme = context.globals.theme;
+      applyTheme(isTheme(theme) ? theme : "auto", document);
       return (
         <div
           className="mbu-surface"

--- a/src/components/icon.stories.tsx
+++ b/src/components/icon.stories.tsx
@@ -34,8 +34,8 @@ function IconGallery(): React.JSX.Element {
             gap: 10,
             padding: 12,
             borderRadius: 12,
-            border: "1px solid rgba(0,0,0,0.12)",
-            background: "rgba(255,255,255,0.9)",
+            border: "1px solid var(--color-border-ui)",
+            background: "var(--color-surface)",
           }}
         >
           <Icon aria-hidden="true" data-testid={`icon-${name}`} name={name} />


### PR DESCRIPTION
## 概要

Storybook の `Components/Icon` で、カード背景が白固定なのにテキスト/アイコンがダークテーマの `--color-text` のままになり、白地に白で見えづらい状態になっていました。
テーマ別にアイコンの見え方を確認しやすくするため、Storybook 側にテーマ切替を用意し、Icon Gallery のカード配色をテーマトークンに追従させました。

- Storybook toolbar に theme（auto/dark/light）を追加し、`data-theme` を切り替え
- Icon Gallery のカードを `var(--color-surface)` / `var(--color-border-ui)` に変更してテーマ追従

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [x] 動作確認完了（Storybook/Vitest addon で `Components/Icon` がレンダリングされることを確認）
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
