### PR TITLE
ピン留めを右上固定しPopoverで説明を表示

### DIFF
--- a/src/styles/tokens/components.css
+++ b/src/styles/tokens/components.css
@@ -366,6 +366,51 @@
   justify-content: flex-end;
 }
 
+.mbu-overlay-popover {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.mbu-overlay-popover-content {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 180px;
+  max-width: min(240px, 70vw);
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--mbu-border);
+  background: color-mix(in oklab, var(--mbu-surface) 94%, transparent);
+  color: var(--mbu-text);
+  box-shadow: var(--mbu-shadow);
+  font-size: 11px;
+  line-height: 1.4;
+  opacity: 0;
+  transform: translateY(-4px) scale(0.98);
+  pointer-events: none;
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+  z-index: 2;
+}
+
+.mbu-overlay-popover-title {
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.mbu-overlay-popover-text {
+  color: var(--mbu-text-muted);
+}
+
+.mbu-overlay-popover:hover .mbu-overlay-popover-content,
+.mbu-overlay-popover:focus-within .mbu-overlay-popover-content {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
 .mbu-overlay-action {
   appearance: none;
   border: 1px solid var(--mbu-border);


### PR DESCRIPTION
## 概要

- 変更内容: オーバーレイのピン留めを右上固定に統一し、ピンアイコンの説明をBase UI Popoverで表示
- 背景: ピン留め位置がマウス下で分かりづらく、アイコンの意図が伝わりにくかったため
- 実装ポイント: PopoverをShadowRootにポータルしてホバー/フォーカスで説明表示、矢印付きスタイルを追加。StorybookのoptimizeDepsにpopoverを追加して安定化

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

- なし

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
