### PR TITLE
ダークモードのアクセント色が埋もれないよう混合率を調整

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -23,12 +23,12 @@ body {
   background:
     radial-gradient(
       circle at 20% 20%,
-      color-mix(in oklab, var(--color-primary) 8%, transparent),
+      color-mix(in oklab, var(--color-primary) var(--accent-mix-8), transparent),
       transparent 30%
     ),
     radial-gradient(
       circle at 80% 0%,
-      color-mix(in oklab, var(--color-primary-2) 8%, transparent),
+      color-mix(in oklab, var(--color-primary-2) var(--accent-mix-8), transparent),
       transparent 28%
     ), var(--color-bg);
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -166,8 +166,16 @@ body.menu-open .menu-drawer {
 .menu-item[aria-selected="true"] {
   background: linear-gradient(
     135deg,
-    color-mix(in oklab, var(--color-primary) 18%, transparent),
-    color-mix(in oklab, var(--color-primary-2) 12%, transparent)
+    color-mix(
+      in oklab,
+      var(--color-primary) var(--accent-mix-18),
+      transparent
+    ),
+    color-mix(
+      in oklab,
+      var(--color-primary-2) var(--accent-mix-12),
+      transparent
+    )
   );
 }
 
@@ -298,7 +306,12 @@ body.menu-open .sidebar {
   display: grid;
   place-items: center;
   background: color-mix(in oklab, var(--color-bg) 70%, transparent);
-  border: 1px solid color-mix(in oklab, var(--color-primary-2) 12%, transparent);
+  border: 1px solid
+    color-mix(
+      in oklab,
+      var(--color-primary-2) var(--accent-mix-12),
+      transparent
+    );
   box-shadow: inset 0 0 0 1px
     color-mix(in oklab, var(--color-bg) 65%, transparent);
 }
@@ -337,7 +350,12 @@ body.menu-open .sidebar {
   padding: 8px 10px;
   border-radius: 12px;
   background: color-mix(in oklab, var(--color-bg) 92%, transparent);
-  border: 1px solid color-mix(in oklab, var(--color-primary-2) 18%, transparent);
+  border: 1px solid
+    color-mix(
+      in oklab,
+      var(--color-primary-2) var(--accent-mix-18),
+      transparent
+    );
   color: var(--text);
   font-size: 12px;
   letter-spacing: 0.2px;
@@ -362,7 +380,11 @@ body.menu-open .sidebar {
 
 .nav-item:hover .nav-icon {
   background: color-mix(in oklab, var(--color-surface-2) 65%, transparent);
-  border-color: color-mix(in oklab, var(--color-primary-2) 22%, transparent);
+  border-color: color-mix(
+    in oklab,
+    var(--color-primary-2) var(--accent-mix-22),
+    transparent
+  );
 }
 
 .nav-item.active,
@@ -478,7 +500,12 @@ body.menu-open .sidebar {
   place-items: center;
   box-shadow:
     0 18px 40px rgba(0, 0, 0, 0.28),
-    0 0 0 1px color-mix(in oklab, var(--color-primary-2) 12%, transparent);
+    0 0 0 1px
+      color-mix(
+        in oklab,
+        var(--color-primary-2) var(--accent-mix-12),
+        transparent
+      );
   position: relative;
   overflow: hidden;
   isolation: isolate;

--- a/src/styles/tokens/components.css
+++ b/src/styles/tokens/components.css
@@ -218,7 +218,11 @@
   border-radius: 999px;
   background: var(--toast-accent);
   box-shadow: 0 0 0 3px
-    color-mix(in oklab, var(--toast-accent) 18%, transparent);
+    color-mix(
+      in oklab,
+      var(--toast-accent) var(--accent-mix-18),
+      transparent
+    );
   flex: 0 0 auto;
 }
 
@@ -618,11 +622,19 @@
 .chip-outline {
   border: 1px solid color-mix(in oklab, var(--color-primary) 60%, transparent);
   color: var(--color-primary);
-  background: color-mix(in oklab, var(--color-primary) 8%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--color-primary) var(--accent-mix-8),
+    transparent
+  );
 }
 
 .chip-soft {
-  background: color-mix(in oklab, var(--color-primary-2) 15%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--color-primary-2) var(--accent-mix-15),
+    transparent
+  );
   color: color-mix(in oklab, var(--color-primary-2) 65%, var(--color-text));
 }
 
@@ -840,7 +852,11 @@ body.no-js:has(.pane:target) .pane.active:not(:target) {
 .mbu-radio-root[data-checked],
 .mbu-radio-root[aria-checked="true"] {
   border-color: color-mix(in oklab, var(--color-primary) 35%, var(--line));
-  background: color-mix(in oklab, var(--color-primary) 14%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--color-primary) var(--accent-mix-14),
+    transparent
+  );
 }
 
 .mbu-radio-root[data-checked] .mbu-radio-indicator,
@@ -1048,7 +1064,11 @@ body.no-js:has(.pane:target) .pane.active:not(:target) {
 }
 
 .mbu-select-item[data-selected] {
-  background: color-mix(in oklab, var(--color-primary) 12%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--color-primary) var(--accent-mix-12),
+    transparent
+  );
 }
 
 .mbu-select-indicator {
@@ -1091,7 +1111,11 @@ body.no-js:has(.pane:target) .pane.active:not(:target) {
 .mbu-toggle[data-pressed] {
   color: var(--text);
   border-color: color-mix(in oklab, var(--color-primary) 35%, var(--line));
-  background: color-mix(in oklab, var(--color-primary) 14%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--color-primary) var(--accent-mix-14),
+    transparent
+  );
 }
 
 .mbu-toggle-inline {
@@ -1127,7 +1151,11 @@ body.no-js:has(.pane:target) .pane.active:not(:target) {
 }
 
 .mbu-toggle-group-item[data-pressed] {
-  background: color-mix(in oklab, var(--color-primary) 14%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--color-primary) var(--accent-mix-14),
+    transparent
+  );
   color: var(--text);
 }
 
@@ -1200,7 +1228,11 @@ body.no-js:has(.pane:target) .pane.active:not(:target) {
 
 .btn-delete {
   border: none;
-  background: color-mix(in oklab, var(--color-danger) 14%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--color-danger) var(--accent-mix-14),
+    transparent
+  );
   color: color-mix(in oklab, var(--color-danger) 65%, var(--color-text));
   padding: var(--button-padding-sm);
   border-radius: var(--button-radius-sm);

--- a/src/styles/tokens/semantic.css
+++ b/src/styles/tokens/semantic.css
@@ -61,6 +61,12 @@
   --color-primary: var(--primitive-color-green-500);
   --color-primary-2: var(--primitive-color-cyan-300);
   --color-danger: var(--primitive-color-red-400);
+  --accent-mix-8: 18%;
+  --accent-mix-12: 24%;
+  --accent-mix-14: 26%;
+  --accent-mix-15: 26%;
+  --accent-mix-18: 30%;
+  --accent-mix-22: 34%;
 
   --shadow-elevation: var(--primitive-shadow-dark);
   --focus-ring: 2px solid rgba(123, 220, 247, 0.55);
@@ -84,6 +90,12 @@
   --color-primary: var(--primitive-color-green-500);
   --color-primary-2: var(--primitive-color-cyan-300);
   --color-danger: var(--primitive-color-red-400);
+  --accent-mix-8: 18%;
+  --accent-mix-12: 24%;
+  --accent-mix-14: 26%;
+  --accent-mix-15: 26%;
+  --accent-mix-18: 30%;
+  --accent-mix-22: 34%;
 
   --shadow-elevation: var(--primitive-shadow-dark);
   --focus-ring: 2px solid rgba(123, 220, 247, 0.55);
@@ -106,6 +118,12 @@
   --color-primary: var(--primitive-color-blue-500);
   --color-primary-2: var(--primitive-color-cyan-300);
   --color-danger: var(--primitive-color-red-600);
+  --accent-mix-8: 8%;
+  --accent-mix-12: 12%;
+  --accent-mix-14: 14%;
+  --accent-mix-15: 15%;
+  --accent-mix-18: 18%;
+  --accent-mix-22: 22%;
 
   --shadow-elevation: var(--primitive-shadow-light);
   --focus-ring: 2px solid rgba(66, 133, 244, 0.65);
@@ -128,6 +146,12 @@
   --color-primary: var(--primitive-color-blue-500);
   --color-primary-2: var(--primitive-color-cyan-300);
   --color-danger: var(--primitive-color-red-600);
+  --accent-mix-8: 8%;
+  --accent-mix-12: 12%;
+  --accent-mix-14: 14%;
+  --accent-mix-15: 15%;
+  --accent-mix-18: 18%;
+  --accent-mix-22: 22%;
 
   --shadow-elevation: var(--primitive-shadow-light);
   --focus-ring: 2px solid rgba(66, 133, 244, 0.65);
@@ -151,6 +175,12 @@
     --color-primary: var(--primitive-color-blue-500);
     --color-primary-2: var(--primitive-color-cyan-300);
     --color-danger: var(--primitive-color-red-600);
+    --accent-mix-8: 8%;
+    --accent-mix-12: 12%;
+    --accent-mix-14: 14%;
+    --accent-mix-15: 15%;
+    --accent-mix-18: 18%;
+    --accent-mix-22: 22%;
 
     --shadow-elevation: var(--primitive-shadow-light);
     --focus-ring: 2px solid rgba(66, 133, 244, 0.65);
@@ -173,6 +203,12 @@
     --color-primary: var(--primitive-color-blue-500);
     --color-primary-2: var(--primitive-color-cyan-300);
     --color-danger: var(--primitive-color-red-600);
+    --accent-mix-8: 8%;
+    --accent-mix-12: 12%;
+    --accent-mix-14: 14%;
+    --accent-mix-15: 15%;
+    --accent-mix-18: 18%;
+    --accent-mix-22: 22%;
 
     --shadow-elevation: var(--primitive-shadow-light);
     --focus-ring: 2px solid rgba(66, 133, 244, 0.65);


### PR DESCRIPTION
## 概要

- 変更内容: テーマ別の色混合率トークン（`--accent-mix-*`）を追加し、淡いアクセント背景（グラデーション、選択状態、チップ/トグル/トースト等）をトークン参照に置換
- 変更理由: ダークモード時に透明寄りの `color-mix(..., transparent)` が強く働き、アクセント色が消えて見えるため
- 実装ポイント: ダークテーマのみ混合率を引き上げ、ライトテーマは従来比率を維持（ポップアップ/オーバーレイの共通トークンで統一）

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [ ] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
