### PR TITLE
アクション編集でevent種別の説明ポップオーバーを追加

### DIFF
--- a/src/popup/panes/actions/ActionEditorPanel.tsx
+++ b/src/popup/panes/actions/ActionEditorPanel.tsx
@@ -2,6 +2,7 @@ import { Button } from "@base-ui/react/button";
 import { Fieldset } from "@base-ui/react/fieldset";
 import { Form } from "@base-ui/react/form";
 import { Input } from "@base-ui/react/input";
+import { Popover } from "@base-ui/react/popover";
 import { Select } from "@base-ui/react/select";
 import { Toggle } from "@base-ui/react/toggle";
 import { ToggleGroup } from "@base-ui/react/toggle-group";
@@ -107,7 +108,34 @@ export function ActionEditorPanel(props: Props): React.JSX.Element {
           </label>
 
           <div className="field">
-            <span className="field-name">種類</span>
+            <div className="field-row">
+              <span className="field-name">種類</span>
+              <Popover.Root>
+                <Popover.Trigger
+                  aria-label="eventとは"
+                  className="mbu-popover-trigger"
+                  type="button"
+                >
+                  ?
+                </Popover.Trigger>
+                <Popover.Portal>
+                  <Popover.Positioner
+                    className="mbu-popover-positioner"
+                    sideOffset={6}
+                  >
+                    <Popover.Popup className="mbu-popover">
+                      <Popover.Title className="mbu-popover-title">
+                        event とは
+                      </Popover.Title>
+                      <Popover.Description className="mbu-popover-description">
+                        event は日時・場所・概要などを抽出してイベント形式で返すモードです。
+                        text はプロンプトに従って要約/翻訳などを行います。
+                      </Popover.Description>
+                    </Popover.Popup>
+                  </Popover.Positioner>
+                </Popover.Portal>
+              </Popover.Root>
+            </div>
             <ToggleGroup
               className="mbu-toggle-group"
               data-testid="action-editor-kind"

--- a/src/styles/tokens/components.css
+++ b/src/styles/tokens/components.css
@@ -710,6 +710,67 @@ body.no-js:has(.pane:target) .pane.active:not(:target) {
   color: var(--text-sub);
 }
 
+.field-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.mbu-popover-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: color-mix(in oklab, var(--panel) 70%, transparent);
+  color: var(--text-sub);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.mbu-popover-trigger:hover {
+  background: color-mix(in oklab, var(--panel) 85%, transparent);
+  color: var(--text);
+}
+
+.mbu-popover-trigger:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--color-primary) 70%, white);
+  outline-offset: 2px;
+}
+
+.mbu-popover-positioner {
+  z-index: 20;
+}
+
+.mbu-popover {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+  padding: 10px 12px;
+  display: grid;
+  gap: 6px;
+  width: min(260px, 70vw);
+}
+
+.mbu-popover-title {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.mbu-popover-description {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-sub);
+}
+
 .output-panel {
   display: grid;
   gap: 10px;


### PR DESCRIPTION
## 概要

- event種別の意味が分かりにくかったため、アクション編集の「種類」に説明ポップオーバーを追加
- event/text の違いを明示（イベント抽出 vs プロンプト処理）
- Base UI Popover を利用し、既存トークンで軽量にスタイル調整

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

- なし

## 確認済み

- [ ] 動作確認完了
- [ ] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
