### PR TITLE
Biome指摘の整形修正と不要なundefined削除

### DIFF
--- a/src/popup/panes/actions/ActionEditorPanel.tsx
+++ b/src/popup/panes/actions/ActionEditorPanel.tsx
@@ -128,7 +128,8 @@ export function ActionEditorPanel(props: Props): React.JSX.Element {
                         event とは
                       </Popover.Title>
                       <Popover.Description className="mbu-popover-description">
-                        event は日時・場所・概要などを抽出してイベント形式で返すモードです。
+                        event
+                        は日時・場所・概要などを抽出してイベント形式で返すモードです。
                         text はプロンプトに従って要約/翻訳などを行います。
                       </Popover.Description>
                     </Popover.Popup>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -23,12 +23,20 @@ body {
   background:
     radial-gradient(
       circle at 20% 20%,
-      color-mix(in oklab, var(--color-primary) var(--accent-mix-8), transparent),
+      color-mix(
+        in oklab,
+        var(--color-primary) var(--accent-mix-8),
+        transparent
+      ),
       transparent 30%
     ),
     radial-gradient(
       circle at 80% 0%,
-      color-mix(in oklab, var(--color-primary-2) var(--accent-mix-8), transparent),
+      color-mix(
+        in oklab,
+        var(--color-primary-2) var(--accent-mix-8),
+        transparent
+      ),
       transparent 28%
     ), var(--color-bg);
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -166,11 +166,7 @@ body.menu-open .menu-drawer {
 .menu-item[aria-selected="true"] {
   background: linear-gradient(
     135deg,
-    color-mix(
-      in oklab,
-      var(--color-primary) var(--accent-mix-18),
-      transparent
-    ),
+    color-mix(in oklab, var(--color-primary) var(--accent-mix-18), transparent),
     color-mix(
       in oklab,
       var(--color-primary-2) var(--accent-mix-12),
@@ -501,11 +497,11 @@ body.menu-open .sidebar {
   box-shadow:
     0 18px 40px rgba(0, 0, 0, 0.28),
     0 0 0 1px
-      color-mix(
-        in oklab,
-        var(--color-primary-2) var(--accent-mix-12),
-        transparent
-      );
+    color-mix(
+      in oklab,
+      var(--color-primary-2) var(--accent-mix-12),
+      transparent
+    );
   position: relative;
   overflow: hidden;
   isolation: isolate;

--- a/src/styles/tokens/components.css
+++ b/src/styles/tokens/components.css
@@ -218,11 +218,7 @@
   border-radius: 999px;
   background: var(--toast-accent);
   box-shadow: 0 0 0 3px
-    color-mix(
-      in oklab,
-      var(--toast-accent) var(--accent-mix-18),
-      transparent
-    );
+    color-mix(in oklab, var(--toast-accent) var(--accent-mix-18), transparent);
   flex: 0 0 auto;
 }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -13,7 +13,7 @@ function readString(value: unknown): string | undefined {
   if (typeof value === "string" && value) {
     return value;
   }
-  return undefined;
+  return;
 }
 
 function extractCause(cause: unknown): string | undefined {


### PR DESCRIPTION
## 概要

- 何を変更したのか: Biomeのフォーマット差分（ActionEditorPanel/CSS）を整形し、`readString` の不要な `return undefined` を削除しました。
- なぜ必要だったのか: `lint:biome` がフォーマット差分と `noUselessUndefined` で失敗していたためです。
- 実装上のポイント: 振る舞い変更はなく、暗黙の `undefined` 返却へ統一して規約に合わせています。

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->