### PR TITLE
fix: オーバーレイの背景フォールバックを追加

### DIFF
--- a/src/styles/tokens/components.css
+++ b/src/styles/tokens/components.css
@@ -86,74 +86,45 @@
   --overlay-shadow: var(--shadow-elevation);
 }
 
-:where(:root),
-:where(:host) {
-  --bg: #0f1724;
-  --bg-2: #1a2334;
-  --panel: #1b2334;
-  --panel-soft: #232d42;
-  --line: rgba(255, 255, 255, 0.12);
-  --text: #f6f7fb;
-  --text-sub: #c8d0e5;
-  --accent: #3ecf8e;
-  --accent-2: #7bdcf7;
-  --danger: #e57373;
-  --shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
-  --radius: 14px;
+@layer fallback {
+  :where(:root),
+  :where(:host) {
+    --bg: #0f1724;
+    --bg-2: #1a2334;
+    --panel: #1b2334;
+    --panel-soft: #232d42;
+    --line: rgba(255, 255, 255, 0.12);
+    --text: #f6f7fb;
+    --text-sub: #c8d0e5;
+    --accent: #3ecf8e;
+    --accent-2: #7bdcf7;
+    --danger: #e57373;
+    --shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+    --radius: 14px;
 
-  --popup-width: 800px;
-  --popup-height: 600px;
-  --rail: 76px;
-  --drawer: 284px;
+    --popup-width: 800px;
+    --popup-height: 600px;
+    --rail: 76px;
+    --drawer: 284px;
 
-  --mbu-bg: #0f1724;
-  --mbu-surface: #1b2334;
-  --mbu-surface-2: #232d42;
-  --mbu-border: rgba(255, 255, 255, 0.12);
-  --mbu-text: #f6f7fb;
-  --mbu-text-muted: #c8d0e5;
-  --mbu-accent: #3ecf8e;
-  --mbu-danger: #e57373;
-  --mbu-radius: 14px;
-  --mbu-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
-  --mbu-focus-ring: 2px solid rgba(123, 220, 247, 0.55);
-  --mbu-focus-ring-offset: 2px;
-  --mbu-toast-screen-inset: 12px 12px auto auto;
-  --mbu-toast-surface-inset: 12px 12px auto auto;
-}
+    --mbu-bg: #0f1724;
+    --mbu-surface: #1b2334;
+    --mbu-surface-2: #232d42;
+    --mbu-border: rgba(255, 255, 255, 0.12);
+    --mbu-text: #f6f7fb;
+    --mbu-text-muted: #c8d0e5;
+    --mbu-accent: #3ecf8e;
+    --mbu-danger: #e57373;
+    --mbu-radius: 14px;
+    --mbu-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+    --mbu-focus-ring: 2px solid rgba(123, 220, 247, 0.55);
+    --mbu-focus-ring-offset: 2px;
+    --mbu-toast-screen-inset: 12px 12px auto auto;
+    --mbu-toast-surface-inset: 12px 12px auto auto;
+  }
 
-:where(:root[data-theme="light"]),
-:where(:host([data-theme="light"])) {
-  --bg: #ffffff;
-  --bg-2: #f3f4f6;
-  --panel: #ffffff;
-  --panel-soft: #f3f4f6;
-  --line: rgba(0, 0, 0, 0.12);
-  --text: #111827;
-  --text-sub: rgba(17, 24, 39, 0.7);
-  --accent: #4285f4;
-  --accent-2: #7bdcf7;
-  --danger: #e53935;
-  --shadow: 0 16px 44px rgba(0, 0, 0, 0.28);
-  --radius: 14px;
-
-  --mbu-bg: #ffffff;
-  --mbu-surface: #ffffff;
-  --mbu-surface-2: #f3f4f6;
-  --mbu-border: rgba(0, 0, 0, 0.12);
-  --mbu-text: #111827;
-  --mbu-text-muted: rgba(17, 24, 39, 0.7);
-  --mbu-accent: #4285f4;
-  --mbu-danger: #e53935;
-  --mbu-radius: 14px;
-  --mbu-shadow: 0 16px 44px rgba(0, 0, 0, 0.28);
-  --mbu-focus-ring: 2px solid rgba(66, 133, 244, 0.65);
-  --mbu-focus-ring-offset: 2px;
-}
-
-@media (prefers-color-scheme: light) {
-  :where(:root:not([data-theme])),
-  :where(:host:not([data-theme])) {
+  :where(:root[data-theme="light"]),
+  :where(:host([data-theme="light"])) {
     --bg: #ffffff;
     --bg-2: #f3f4f6;
     --panel: #ffffff;
@@ -179,6 +150,37 @@
     --mbu-shadow: 0 16px 44px rgba(0, 0, 0, 0.28);
     --mbu-focus-ring: 2px solid rgba(66, 133, 244, 0.65);
     --mbu-focus-ring-offset: 2px;
+  }
+
+  @media (prefers-color-scheme: light) {
+    :where(:root:not([data-theme])),
+    :where(:host:not([data-theme])) {
+      --bg: #ffffff;
+      --bg-2: #f3f4f6;
+      --panel: #ffffff;
+      --panel-soft: #f3f4f6;
+      --line: rgba(0, 0, 0, 0.12);
+      --text: #111827;
+      --text-sub: rgba(17, 24, 39, 0.7);
+      --accent: #4285f4;
+      --accent-2: #7bdcf7;
+      --danger: #e53935;
+      --shadow: 0 16px 44px rgba(0, 0, 0, 0.28);
+      --radius: 14px;
+
+      --mbu-bg: #ffffff;
+      --mbu-surface: #ffffff;
+      --mbu-surface-2: #f3f4f6;
+      --mbu-border: rgba(0, 0, 0, 0.12);
+      --mbu-text: #111827;
+      --mbu-text-muted: rgba(17, 24, 39, 0.7);
+      --mbu-accent: #4285f4;
+      --mbu-danger: #e53935;
+      --mbu-radius: 14px;
+      --mbu-shadow: 0 16px 44px rgba(0, 0, 0, 0.28);
+      --mbu-focus-ring: 2px solid rgba(66, 133, 244, 0.65);
+      --mbu-focus-ring-offset: 2px;
+    }
   }
 }
 


### PR DESCRIPTION
## 概要
- 右クリックオーバーレイでトークンCSSが読めない場合でも背景/文字色が入るようフォールバックトークンを追加
- Storybookでトークン未注入時のフォールバック適用を検証するストーリーを追加

## 背景
- 右クリックメニューから開くオーバーレイでCSSが未適用になり背景が抜けるケースがあったため

## 確認観点
- Token CSSが未読み込みでも `.mbu-overlay-panel` の背景が透明にならないこと
- 通常時は既存のトークンが優先され、見た目が変わらないこと

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
