### PR TITLE
サイズ型の共通化とコンテキストメニュー引数型の整理

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -196,6 +196,14 @@ type ContextMenuTabParams = {
   tab?: chrome.tabs.Tab;
 };
 
+type ContextMenuClickParams = ContextMenuTabParams & {
+  info: chrome.contextMenus.OnClickData;
+};
+
+type ContextMenuActionClickParams = ContextMenuClickParams & {
+  menuItemId: string;
+};
+
 type ContextMenuTargetParams = ContextMenuTabParams & {
   selection: string;
 };
@@ -376,11 +384,9 @@ async function showContextMenuUnexpectedErrorOverlay(
   });
 }
 
-async function handleCalendarContextMenuClick(params: {
-  tabId: number;
-  info: chrome.contextMenus.OnClickData;
-  tab?: chrome.tabs.Tab;
-}): Promise<void> {
+async function handleCalendarContextMenuClick(
+  params: ContextMenuClickParams
+): Promise<void> {
   const context = buildContextMenuSelectionContext(params.info);
   const initialSuffix = titleSuffixBySource(context.initialSource);
   const initialTitle = `カレンダー登録（${initialSuffix}）`;
@@ -452,12 +458,9 @@ async function handleCalendarContextMenuClick(params: {
   } satisfies ContentScriptMessage);
 }
 
-async function handleContextMenuClick(params: {
-  tabId: number;
-  menuItemId: string;
-  info: chrome.contextMenus.OnClickData;
-  tab?: chrome.tabs.Tab;
-}): Promise<void> {
+async function handleContextMenuClick(
+  params: ContextMenuActionClickParams
+): Promise<void> {
   const context = buildContextMenuSelectionContext(params.info);
   const actionId = params.menuItemId.slice(CONTEXT_MENU_ACTION_PREFIX.length);
 

--- a/src/content/overlay/OverlayApp.tsx
+++ b/src/content/overlay/OverlayApp.tsx
@@ -2,7 +2,7 @@ import { Button } from "@base-ui/react/button";
 import { useId, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { AuxTextDisclosure } from "@/components/AuxTextDisclosure";
 import { CopyIcon, PinIcon } from "@/content/overlay/icons";
-import type { ExtractedEvent, SummarySource } from "@/shared_types";
+import type { ExtractedEvent, Size, SummarySource } from "@/shared_types";
 import { createNotifications, ToastHost } from "@/ui/toast";
 
 export type OverlayViewModel = {
@@ -133,7 +133,7 @@ type OverlayNotify = ReturnType<typeof createNotifications>["notify"];
 type StateSetter<T> = React.Dispatch<React.SetStateAction<T>>;
 
 type DragOffset = { x: number; y: number };
-type PanelSize = { width: number; height: number };
+type PanelSize = Size;
 
 function getPanelSize(panel: HTMLDivElement | null): PanelSize {
   const rect = panel?.getBoundingClientRect();

--- a/src/shared_types.ts
+++ b/src/shared_types.ts
@@ -1,5 +1,10 @@
 export type SummarySource = "selection" | "page";
 
+export type Size = {
+  width: number;
+  height: number;
+};
+
 export type ExtractedEvent = {
   title: string;
   start: string;

--- a/tests/content.overlay_app_positioning.test.tsx
+++ b/tests/content.overlay_app_positioning.test.tsx
@@ -5,6 +5,7 @@ import {
   OverlayApp,
   type OverlayViewModel,
 } from "@/content/overlay/OverlayApp";
+import type { Size } from "@/shared_types";
 
 // Enable React's act() behavior warnings to be handled correctly in this test suite.
 (
@@ -17,7 +18,7 @@ async function flushEffects(times = 3): Promise<void> {
   }
 }
 
-function setWindowSize(size: { width: number; height: number }): void {
+function setWindowSize(size: Size): void {
   Object.defineProperty(window, "innerWidth", {
     configurable: true,
     value: size.width,


### PR DESCRIPTION
## 概要

- similarity-tsの指摘に合わせて、重複していた型リテラルを共通化
- `Size` 型を `src/shared_types.ts` に追加し、OverlayAppとテストで利用
- コンテキストメニューのハンドラ引数型を `ContextMenuClickParams` / `ContextMenuActionClickParams` に整理

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
