### PR TITLE
chore: smol-toml を 1.6.0 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lucide-react": "^0.562.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
-    "smol-toml": "^1.2.1"
+    "smol-toml": "^1.6.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(react@19.2.3)
       smol-toml:
-        specifier: ^1.2.1
+        specifier: ^1.6.0
         version: 1.6.0
     devDependencies:
       '@biomejs/biome':


### PR DESCRIPTION
## 概要

- 何を: smol-toml を ^1.2.1 → ^1.6.0 に更新し、`pnpm-lock.yaml` も追従
- なぜ: `ncu -u` による依存の最新化で、上流の修正・互換性改善を取り込むため
- 重要ポイント/注意点: 依存更新のみでコード変更なし。TOML パース挙動は上流依存のため、既存テストと `mise run ci` で確認

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
