### PR TITLE
CSP下で要約/翻訳オーバーレイの背景が消える問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "pnpm run clean && pnpm run typecheck && pnpm run bundle",
-    "bundle": "esbuild src/background.ts src/content.ts src/popup.ts --bundle --format=iife --platform=browser --target=es2020 --alias:@=./src --define:process.env.NODE_ENV=\\\"production\\\" --loader:.toml=text --outdir=dist --sourcemap",
+    "bundle": "esbuild src/background.ts src/content.ts src/popup.ts --bundle --format=iife --platform=browser --target=es2020 --alias:@=./src --define:process.env.NODE_ENV=\\\"production\\\" --loader:.toml=text --loader:.css=text --outdir=dist --sourcemap",
     "typecheck": "tsc --noEmit",
     "watch": "pnpm run bundle --watch",
     "clean": "rm -rf dist",

--- a/src/types/assets.d.ts
+++ b/src/types/assets.d.ts
@@ -1,0 +1,4 @@
+declare module "*.css?raw" {
+  const content: string;
+  export default content;
+}

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -1,3 +1,7 @@
+import componentsCss from "@/styles/tokens/components.css?raw";
+import primitivesCss from "@/styles/tokens/primitives.css?raw";
+import semanticCss from "@/styles/tokens/semantic.css?raw";
+
 const TOKEN_PRIMITIVES_ID = "mbu-ui-token-primitives";
 const TOKEN_SEMANTIC_ID = "mbu-ui-token-semantic";
 const STYLE_ID = "mbu-ui-base-styles";
@@ -27,6 +31,34 @@ function resolveStyleHref(path: string): string {
   return path;
 }
 
+type ConstructableSheets = {
+  primitives: CSSStyleSheet;
+  semantic: CSSStyleSheet;
+  components: CSSStyleSheet;
+};
+
+function createConstructableSheets(): ConstructableSheets | null {
+  if (typeof CSSStyleSheet === "undefined") {
+    return null;
+  }
+  if (!("replaceSync" in CSSStyleSheet.prototype)) {
+    return null;
+  }
+  try {
+    const primitives = new CSSStyleSheet();
+    primitives.replaceSync(primitivesCss);
+    const semantic = new CSSStyleSheet();
+    semantic.replaceSync(semanticCss);
+    const components = new CSSStyleSheet();
+    components.replaceSync(componentsCss);
+    return { primitives, semantic, components };
+  } catch {
+    return null;
+  }
+}
+
+const shadowConstructedSheets = createConstructableSheets();
+
 function ensureDocumentStylesheet(
   doc: Document,
   id: string,
@@ -42,19 +74,18 @@ function ensureDocumentStylesheet(
   (doc.head ?? doc.documentElement).appendChild(link);
 }
 
-function ensureShadowStylesheet(
+function ensureShadowStyleText(
   shadowRoot: ShadowRoot,
   id: string,
-  path: string
+  cssText: string
 ): void {
   if (shadowRoot.querySelector(`#${id}`)) {
     return;
   }
-  const link = shadowRoot.ownerDocument.createElement("link");
-  link.id = id;
-  link.rel = "stylesheet";
-  link.href = resolveStyleHref(path);
-  shadowRoot.appendChild(link);
+  const style = shadowRoot.ownerDocument.createElement("style");
+  style.id = id;
+  style.textContent = cssText;
+  shadowRoot.appendChild(style);
 }
 
 export function ensurePopupUiBaseStyles(doc: Document): void {
@@ -67,11 +98,31 @@ export function ensurePopupUiBaseStyles(doc: Document): void {
 }
 
 export function ensureShadowUiBaseStyles(shadowRoot: ShadowRoot): void {
-  ensureShadowStylesheet(
-    shadowRoot,
-    TOKEN_PRIMITIVES_ID,
-    TOKEN_PRIMITIVES_PATH
-  );
-  ensureShadowStylesheet(shadowRoot, TOKEN_SEMANTIC_ID, TOKEN_SEMANTIC_PATH);
-  ensureShadowStylesheet(shadowRoot, STYLE_ID, TOKEN_COMPONENTS_PATH);
+  if (
+    shadowConstructedSheets &&
+    "adoptedStyleSheets" in shadowRoot &&
+    Array.isArray(shadowRoot.adoptedStyleSheets)
+  ) {
+    const existing = shadowRoot.adoptedStyleSheets;
+    const next = [...existing];
+    let changed = false;
+    for (const sheet of [
+      shadowConstructedSheets.primitives,
+      shadowConstructedSheets.semantic,
+      shadowConstructedSheets.components,
+    ]) {
+      if (!existing.includes(sheet)) {
+        next.push(sheet);
+        changed = true;
+      }
+    }
+    if (changed) {
+      shadowRoot.adoptedStyleSheets = next;
+    }
+    return;
+  }
+
+  ensureShadowStyleText(shadowRoot, TOKEN_PRIMITIVES_ID, primitivesCss);
+  ensureShadowStyleText(shadowRoot, TOKEN_SEMANTIC_ID, semanticCss);
+  ensureShadowStyleText(shadowRoot, STYLE_ID, componentsCss);
 }

--- a/tests/ui.styles_injection.test.ts
+++ b/tests/ui.styles_injection.test.ts
@@ -4,6 +4,16 @@ import { ensurePopupUiBaseStyles, ensureShadowUiBaseStyles } from "@/ui/styles";
 describe("UI base styles", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    for (const id of [
+      "mbu-ui-token-primitives",
+      "mbu-ui-token-semantic",
+      "mbu-style-base",
+      "mbu-style-layout",
+      "mbu-style-utilities",
+      "mbu-ui-base-styles",
+    ]) {
+      document.getElementById(id)?.remove();
+    }
   });
 
   it("injects popup base styles once", () => {
@@ -39,24 +49,16 @@ describe("UI base styles", () => {
       },
     });
 
-    const host = document.createElement("div");
-    const shadow = host.attachShadow({ mode: "open" });
-    ensureShadowUiBaseStyles(shadow);
+    ensurePopupUiBaseStyles(document);
 
     expect(
-      shadow
-        .querySelector<HTMLLinkElement>("#mbu-ui-token-primitives")
-        ?.getAttribute("href")
+      document.getElementById("mbu-ui-token-primitives")?.getAttribute("href")
     ).toBe("chrome-extension://test/src/styles/tokens/primitives.css");
     expect(
-      shadow
-        .querySelector<HTMLLinkElement>("#mbu-ui-token-semantic")
-        ?.getAttribute("href")
+      document.getElementById("mbu-ui-token-semantic")?.getAttribute("href")
     ).toBe("chrome-extension://test/src/styles/tokens/semantic.css");
     expect(
-      shadow
-        .querySelector<HTMLLinkElement>("#mbu-ui-base-styles")
-        ?.getAttribute("href")
+      document.getElementById("mbu-ui-base-styles")?.getAttribute("href")
     ).toBe("chrome-extension://test/src/styles/tokens/components.css");
   });
 });


### PR DESCRIPTION
## 概要

CSPで外部CSSがブロックされるページでも要約/翻訳オーバーレイに背景色が当たるよう、Shadow DOMのスタイル注入をconstructable stylesheet（非対応環境はstyleタグ）に切り替えました。DevToolsでstyle-srcにより<link>がブロックされることを確認したうえで対策しています。

- 変更内容: ShadowRootへのスタイル注入を文字列ベースへ変更（adoptedStyleSheets優先）
- 背景: CSP（style-src 'self'）でShadowRoot内<link>がブロックされる
- 確認観点: StorybookのOverlayApp（ReadyStylesApplied）で背景色が適用されること

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue


## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
