### PR TITLE
fix: StorybookでTOMLを文字列として読み込む

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -9,16 +9,14 @@ const dirname =
     ? __dirname
     : path.dirname(fileURLToPath(import.meta.url));
 const srcDir = path.resolve(dirname, "../src");
-const stripQuery = (id: string) => id.split("?", 1)[0];
 const tomlAsText = (): Plugin => ({
   name: "toml-as-text",
   enforce: "pre",
   load(id: string) {
-    const cleanId = stripQuery(id);
-    if (!cleanId.endsWith(".toml")) {
+    if (!id.endsWith(".toml")) {
       return null;
     }
-    const code = fs.readFileSync(cleanId, "utf8");
+    const code = fs.readFileSync(id, "utf8");
     return {
       code: `export default ${JSON.stringify(code)};`,
       map: null,
@@ -39,8 +37,13 @@ const config: StorybookConfig = {
     { from: "../images", to: "/images" },
   ],
   viteFinal(viteConfig) {
-    const plugins = Array.isArray(viteConfig.plugins) ? viteConfig.plugins : [];
-    viteConfig.plugins = [tomlAsText(), ...plugins];
+    const plugins: Plugin[] = [];
+    if (Array.isArray(viteConfig.plugins)) {
+      plugins.push(...viteConfig.plugins);
+    } else if (viteConfig.plugins) {
+      plugins.push(viteConfig.plugins);
+    }
+    viteConfig.plugins = [...plugins, tomlAsText()];
 
     viteConfig.resolve ??= {};
     const alias = viteConfig.resolve.alias;


### PR DESCRIPTION
## 概要

ActionsPane/CalendarPane の Storybook 表示で .toml import が失敗していたため、Vite 側で TOML を文字列として読み込むプラグインを追加しました。

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
