### PR TITLE
fix: ピン留め挙動とアコーディオン状態の保持

### DIFF
--- a/src/components/AuxTextDisclosure.tsx
+++ b/src/components/AuxTextDisclosure.tsx
@@ -1,17 +1,86 @@
+import { useEffect, useState } from "react";
+
 type Props = {
   summary: string;
   text: string;
   defaultOpen?: boolean;
+  storageKey?: string;
 };
 
 export function AuxTextDisclosure(props: Props): React.JSX.Element | null {
   const trimmed = props.text.trim();
+  const fallbackOpen = props.defaultOpen ?? false;
+  const [open, setOpen] = useState(fallbackOpen);
+
+  useEffect(() => {
+    let disposed = false;
+    const storageKey = props.storageKey;
+    if (!storageKey) {
+      setOpen(fallbackOpen);
+      return () => {
+        disposed = true;
+      };
+    }
+    if (typeof chrome === "undefined") {
+      setOpen(fallbackOpen);
+      return () => {
+        disposed = true;
+      };
+    }
+    const storage = chrome.storage?.local;
+    if (!storage) {
+      setOpen(fallbackOpen);
+      return () => {
+        disposed = true;
+      };
+    }
+
+    storage.get([storageKey], (items) => {
+      if (disposed) {
+        return;
+      }
+      const err = chrome.runtime?.lastError;
+      if (err) {
+        setOpen(fallbackOpen);
+        return;
+      }
+      const value = (items as Record<string, unknown>)[storageKey];
+      setOpen(typeof value === "boolean" ? value : fallbackOpen);
+    });
+
+    return () => {
+      disposed = true;
+    };
+  }, [fallbackOpen, props.storageKey]);
+
+  const handleToggle = (
+    event: React.SyntheticEvent<HTMLDetailsElement>
+  ): void => {
+    const nextOpen = event.currentTarget.open;
+    setOpen(nextOpen);
+
+    const storageKey = props.storageKey;
+    if (!storageKey) {
+      return;
+    }
+    if (typeof chrome === "undefined") {
+      return;
+    }
+    const storage = chrome.storage?.local;
+    if (!storage) {
+      return;
+    }
+    storage.set({ [storageKey]: nextOpen }, () => {
+      // no-op
+    });
+  };
+
   if (!trimmed) {
     return null;
   }
 
   return (
-    <details className="mbu-overlay-aux" open={props.defaultOpen}>
+    <details className="mbu-overlay-aux" onToggle={handleToggle} open={open}>
       <summary className="mbu-overlay-aux-summary">{props.summary}</summary>
       <blockquote className="mbu-overlay-quote">{trimmed}</blockquote>
     </details>

--- a/src/styles/tokens/components.css
+++ b/src/styles/tokens/components.css
@@ -423,6 +423,13 @@
   padding: 10px 12px;
   background: color-mix(in oklab, var(--mbu-surface-2) 75%, transparent);
   border-bottom: 1px solid var(--mbu-border);
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+
+.mbu-overlay-header[data-dragging="true"] {
+  cursor: grabbing;
 }
 
 .mbu-overlay-header-left {


### PR DESCRIPTION
## 概要

- ピン留め中は固定し、ヘッダーでドラッグするとピン解除して移動するように調整
- 「選択したテキスト（確認用）」の開閉状態をローカル保存

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

-

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
