### PR TITLE
fix: toastの表示位置を右寄せに修正

### DIFF
--- a/src/styles/tokens/components.css
+++ b/src/styles/tokens/components.css
@@ -261,7 +261,7 @@
 .mbu-toast-viewport[data-placement="surface"] {
   position: absolute;
   inset: var(--toast-surface-inset, 12px 12px auto auto);
-  align-items: center;
+  align-items: flex-end;
 }
 
 .mbu-toast-viewport[data-placement="surface"] .mbu-toast-root {


### PR DESCRIPTION
## 概要

アラート用トースト（surface placement）が中央寄せになる挙動を修正し、右端起点で表示されるようにしました。

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

- なし

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`mise run ci`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
