### PR TITLE
テーブルソートの自動有効化をスイッチUIに変更

### DIFF
--- a/src/popup/panes/TablePane.tsx
+++ b/src/popup/panes/TablePane.tsx
@@ -2,9 +2,9 @@ import { Button } from "@base-ui/react/button";
 import { Form } from "@base-ui/react/form";
 import { Input } from "@base-ui/react/input";
 import { ScrollArea } from "@base-ui/react/scroll-area";
-import { Toggle } from "@base-ui/react/toggle";
+import { Switch } from "@base-ui/react/switch";
 import { Result } from "@praha/byethrow";
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import type { PopupPaneBaseProps } from "@/popup/panes/types";
 import type { EnableTableSortMessage } from "@/popup/runtime";
 
@@ -24,6 +24,7 @@ export function TablePane(props: TablePaneProps): React.JSX.Element {
   const [autoEnable, setAutoEnable] = useState(false);
   const [patterns, setPatterns] = useState<string[]>([]);
   const [patternInput, setPatternInput] = useState("");
+  const autoEnableLabelId = useId();
 
   useEffect(() => {
     let cancelled = false;
@@ -139,19 +140,24 @@ export function TablePane(props: TablePaneProps): React.JSX.Element {
         </Button>
       </div>
 
-      <Toggle
-        className="mbu-toggle-inline"
-        data-testid="auto-enable-sort"
-        onPressedChange={(pressed) => {
-          toggleAutoEnable(pressed).catch(() => {
-            // no-op
-          });
-        }}
-        pressed={autoEnable}
-        type="button"
-      >
-        自動で有効化する
-      </Toggle>
+      <div className="mbu-switch-field">
+        <span className="mbu-switch-text" id={autoEnableLabelId}>
+          自動で有効化する
+        </span>
+        <Switch.Root
+          aria-labelledby={autoEnableLabelId}
+          checked={autoEnable}
+          className="mbu-switch"
+          data-testid="auto-enable-sort"
+          onCheckedChange={(checked) => {
+            toggleAutoEnable(checked).catch(() => {
+              // no-op
+            });
+          }}
+        >
+          <Switch.Thumb className="mbu-switch-thumb" />
+        </Switch.Root>
+      </div>
 
       <div className="stack">
         <div className="hint">

--- a/src/styles/tokens/components.css
+++ b/src/styles/tokens/components.css
@@ -1366,6 +1366,79 @@ body.no-js:has(.pane:target) .pane.active:not(:target) {
   color: var(--text);
 }
 
+.mbu-switch-field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 10px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: color-mix(in oklab, var(--color-text) 4%, transparent);
+  color: var(--text);
+  cursor: pointer;
+  user-select: none;
+}
+
+.mbu-switch-text {
+  color: inherit;
+  font-weight: 500;
+}
+
+.mbu-switch {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  width: 44px;
+  height: 24px;
+  padding: 2px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: color-mix(in oklab, var(--color-text) 8%, transparent);
+  transition:
+    background 160ms ease,
+    border-color 160ms ease;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.mbu-switch[data-checked] {
+  background: color-mix(
+    in oklab,
+    var(--color-primary) var(--accent-mix-18),
+    transparent
+  );
+  border-color: color-mix(
+    in oklab,
+    var(--color-primary) var(--accent-mix-40),
+    var(--line)
+  );
+}
+
+.mbu-switch[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.mbu-switch[data-focused] {
+  box-shadow: 0 0 0 2px
+    color-mix(in oklab, var(--color-primary) 35%, transparent);
+}
+
+.mbu-switch-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--color-surface);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  transform: translateX(0);
+  transition: transform 160ms ease;
+}
+
+.mbu-switch[data-checked] .mbu-switch-thumb {
+  transform: translateX(22px);
+}
+
 .pattern-list {
   max-height: 240px;
   border: 1px dashed var(--line);


### PR DESCRIPTION
## 概要

テーブルソートの自動有効化をトグルボタンからスイッチUIへ変更し、操作感を改善しました。

## 種別

- [x] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
