### PR TITLE
fix: popupのCSSをbuild出力から読み込む

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
     "node": "24.8.0"
   },
   "scripts": {
-    "build": "pnpm run clean && pnpm run typecheck && pnpm run bundle",
+    "build": "pnpm run clean && pnpm run typecheck && pnpm run bundle && pnpm run copy:styles",
     "bundle": "esbuild src/background.ts src/content.ts src/popup.ts --bundle --format=iife --platform=browser --target=es2020 --alias:@=./src --define:process.env.NODE_ENV=\\\"production\\\" --loader:.toml=text --loader:.css=text --outdir=dist --sourcemap",
+    "copy:styles": "mkdir -p dist/styles && cp -R src/styles/* dist/styles/",
     "typecheck": "tsc --noEmit",
-    "watch": "pnpm run bundle --watch",
+    "watch": "pnpm run copy:styles && pnpm run bundle --watch",
     "clean": "rm -rf dist",
     "test": "vitest run --project=unit",
     "test:watch": "vitest --project=unit",

--- a/popup.html
+++ b/popup.html
@@ -7,24 +7,24 @@
     <link
       id="mbu-ui-token-primitives"
       rel="stylesheet"
-      href="src/styles/tokens/primitives.css"
+      href="dist/styles/tokens/primitives.css"
     >
     <link
       id="mbu-ui-token-semantic"
       rel="stylesheet"
-      href="src/styles/tokens/semantic.css"
+      href="dist/styles/tokens/semantic.css"
     >
-    <link id="mbu-style-base" rel="stylesheet" href="src/styles/base.css">
-    <link id="mbu-style-layout" rel="stylesheet" href="src/styles/layout.css">
+    <link id="mbu-style-base" rel="stylesheet" href="dist/styles/base.css">
+    <link id="mbu-style-layout" rel="stylesheet" href="dist/styles/layout.css">
     <link
       id="mbu-style-utilities"
       rel="stylesheet"
-      href="src/styles/utilities.css"
+      href="dist/styles/utilities.css"
     >
     <link
       id="mbu-ui-base-styles"
       rel="stylesheet"
-      href="src/styles/tokens/components.css"
+      href="dist/styles/tokens/components.css"
     >
   </head>
   <body>

--- a/src/ui/styles.ts
+++ b/src/ui/styles.ts
@@ -6,16 +6,18 @@ const TOKEN_PRIMITIVES_ID = "mbu-ui-token-primitives";
 const TOKEN_SEMANTIC_ID = "mbu-ui-token-semantic";
 const STYLE_ID = "mbu-ui-base-styles";
 
-const TOKEN_PRIMITIVES_PATH = "src/styles/tokens/primitives.css";
-const TOKEN_SEMANTIC_PATH = "src/styles/tokens/semantic.css";
-const TOKEN_COMPONENTS_PATH = "src/styles/tokens/components.css";
+const TOKEN_PRIMITIVES_PATH = "tokens/primitives.css";
+const TOKEN_SEMANTIC_PATH = "tokens/semantic.css";
+const TOKEN_COMPONENTS_PATH = "tokens/components.css";
 const POPUP_BASE_ID = "mbu-style-base";
 const POPUP_LAYOUT_ID = "mbu-style-layout";
 const POPUP_UTILITIES_ID = "mbu-style-utilities";
 
-const POPUP_BASE_PATH = "src/styles/base.css";
-const POPUP_LAYOUT_PATH = "src/styles/layout.css";
-const POPUP_UTILITIES_PATH = "src/styles/utilities.css";
+const POPUP_BASE_PATH = "base.css";
+const POPUP_LAYOUT_PATH = "layout.css";
+const POPUP_UTILITIES_PATH = "utilities.css";
+const POPUP_STYLE_ROOT_DEV = "src/styles";
+const POPUP_STYLE_ROOT_DIST = "dist/styles";
 
 function resolveStyleHref(path: string): string {
   try {
@@ -29,6 +31,21 @@ function resolveStyleHref(path: string): string {
     // non-extension contexts (tests/storybook)
   }
   return path;
+}
+
+function getPopupStyleRoot(doc: Document): string {
+  try {
+    if (doc.location?.protocol === "chrome-extension:") {
+      return POPUP_STYLE_ROOT_DIST;
+    }
+  } catch {
+    // ignore non-browser contexts
+  }
+  return POPUP_STYLE_ROOT_DEV;
+}
+
+function resolvePopupStylePath(doc: Document, relativePath: string): string {
+  return `${getPopupStyleRoot(doc)}/${relativePath}`;
 }
 
 type ConstructableSheets = {
@@ -89,12 +106,36 @@ function ensureShadowStyleText(
 }
 
 export function ensurePopupUiBaseStyles(doc: Document): void {
-  ensureDocumentStylesheet(doc, TOKEN_PRIMITIVES_ID, TOKEN_PRIMITIVES_PATH);
-  ensureDocumentStylesheet(doc, TOKEN_SEMANTIC_ID, TOKEN_SEMANTIC_PATH);
-  ensureDocumentStylesheet(doc, POPUP_BASE_ID, POPUP_BASE_PATH);
-  ensureDocumentStylesheet(doc, POPUP_LAYOUT_ID, POPUP_LAYOUT_PATH);
-  ensureDocumentStylesheet(doc, POPUP_UTILITIES_ID, POPUP_UTILITIES_PATH);
-  ensureDocumentStylesheet(doc, STYLE_ID, TOKEN_COMPONENTS_PATH);
+  ensureDocumentStylesheet(
+    doc,
+    TOKEN_PRIMITIVES_ID,
+    resolvePopupStylePath(doc, TOKEN_PRIMITIVES_PATH)
+  );
+  ensureDocumentStylesheet(
+    doc,
+    TOKEN_SEMANTIC_ID,
+    resolvePopupStylePath(doc, TOKEN_SEMANTIC_PATH)
+  );
+  ensureDocumentStylesheet(
+    doc,
+    POPUP_BASE_ID,
+    resolvePopupStylePath(doc, POPUP_BASE_PATH)
+  );
+  ensureDocumentStylesheet(
+    doc,
+    POPUP_LAYOUT_ID,
+    resolvePopupStylePath(doc, POPUP_LAYOUT_PATH)
+  );
+  ensureDocumentStylesheet(
+    doc,
+    POPUP_UTILITIES_ID,
+    resolvePopupStylePath(doc, POPUP_UTILITIES_PATH)
+  );
+  ensureDocumentStylesheet(
+    doc,
+    STYLE_ID,
+    resolvePopupStylePath(doc, TOKEN_COMPONENTS_PATH)
+  );
 }
 
 export function ensureShadowUiBaseStyles(shadowRoot: ShadowRoot): void {


### PR DESCRIPTION
## 概要

- popupのCSS参照先をbuild出力（dist）に統一
- build時にstylesをdistへコピー
- popup側は拡張機能時にdistのstylesを参照

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue


## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (
> my-browser-utils@1.0.0 lint /private/var/folders/9j/86cfpgbs2gs42ddn9z4xqg15650sjt/T/vibe-kanban/worktrees/5baf-popup-storybook/my-browser-utils
> ultracite check


[38;5;208mUltracite[39m [38;5;208mv6.5.0[39m check
✓ Finished in 26ms on 113 files.
undefined
 ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "type-check" not found

Did you mean "pnpm typecheck"?)
- [ ] Terraform変更時: [32m[1mSuccess![0m The configuration is valid.
[0m

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->