### PR TITLE
feat: Actionsに選択テキスト確認用アコーディオンを追加

### DIFF
--- a/src/popup/panes/actions/ActionTargetAccordion.tsx
+++ b/src/popup/panes/actions/ActionTargetAccordion.tsx
@@ -1,0 +1,53 @@
+import { Accordion } from "@base-ui/react/accordion";
+import type { SummaryTarget } from "@/popup/runtime";
+
+type Props = {
+  sourceLabel: string;
+  target: SummaryTarget;
+};
+
+const MAX_PREVIEW_CHARS = 4000;
+
+export function ActionTargetAccordion(props: Props): React.JSX.Element | null {
+  const trimmed = props.target.text.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const label =
+    props.target.source === "selection"
+      ? "選択したテキスト（確認用）"
+      : "ページ本文（確認用）";
+  const isTruncated = trimmed.length > MAX_PREVIEW_CHARS;
+  const previewText = isTruncated
+    ? `${trimmed.slice(0, MAX_PREVIEW_CHARS)}\n\n(以下省略)`
+    : trimmed;
+
+  return (
+    <Accordion.Root className="mbu-accordion" defaultValue={["target"]}>
+      <Accordion.Item className="mbu-accordion-item" value="target">
+        <Accordion.Header className="mbu-accordion-header">
+          <Accordion.Trigger className="mbu-accordion-trigger" type="button">
+            <span className="mbu-accordion-title">{label}</span>
+            <span aria-hidden="true" className="mbu-accordion-icon">
+              ▾
+            </span>
+          </Accordion.Trigger>
+        </Accordion.Header>
+        <Accordion.Panel className="mbu-accordion-panel">
+          <div className="mbu-accordion-meta">使用元: {props.sourceLabel}</div>
+          {isTruncated ? (
+            <div className="mbu-accordion-note">
+              長文のため先頭4,000文字のみ表示
+            </div>
+          ) : null}
+          <textarea
+            className="summary-output summary-output--sm mbu-accordion-text"
+            readOnly
+            value={previewText}
+          />
+        </Accordion.Panel>
+      </Accordion.Item>
+    </Accordion.Root>
+  );
+}

--- a/src/popup/runtime.ts
+++ b/src/popup/runtime.ts
@@ -24,6 +24,7 @@ export type RunContextActionRequest = {
   action: "runContextAction";
   tabId: number;
   actionId: string;
+  target?: SummaryTarget;
 };
 export type RunContextActionResponse =
   | { ok: true; resultType: "text"; text: string; source: SummarySource }

--- a/src/styles/tokens/components.css
+++ b/src/styles/tokens/components.css
@@ -934,6 +934,69 @@ body.no-js:has(.pane:target) .pane.active:not(:target) {
   gap: 10px;
 }
 
+.mbu-accordion {
+  display: grid;
+  gap: 8px;
+}
+
+.mbu-accordion-item {
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.mbu-accordion-header {
+  margin: 0;
+}
+
+.mbu-accordion-trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+}
+
+.mbu-accordion-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.mbu-accordion-icon {
+  font-size: 12px;
+  transition: transform 0.2s ease;
+}
+
+.mbu-accordion-trigger[aria-expanded="true"] .mbu-accordion-icon {
+  transform: rotate(180deg);
+}
+
+.mbu-accordion-panel {
+  padding: 0 12px 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.mbu-accordion-meta,
+.mbu-accordion-note {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-sub);
+  line-height: 1.4;
+}
+
+.mbu-accordion-text {
+  min-height: 96px;
+}
+
 .editor-panel {
   margin-top: 18px;
   padding-top: 14px;

--- a/tests/helpers/popupChromeStub.ts
+++ b/tests/helpers/popupChromeStub.ts
@@ -75,10 +75,23 @@ export function createPopupChromeStub(): PopupChromeStub {
       ),
       sendMessage: vi.fn((...args: unknown[]) => {
         clearError();
-        const last = args.at(-1);
-        if (typeof last === "function") {
-          (last as (resp: unknown) => void)({ ok: true });
+        const callback = args.find((item) => typeof item === "function") as
+          | ((resp: unknown) => void)
+          | undefined;
+        if (!callback) {
+          return;
         }
+        const message = args[1] as { action?: unknown } | undefined;
+        if (message?.action === "getSummaryTargetText") {
+          callback({
+            text: "stub selection",
+            source: "selection",
+            title: "stub title",
+            url: "https://example.com",
+          });
+          return;
+        }
+        callback({ ok: true });
       }),
       create: vi.fn((_createProperties: unknown, callback?: () => void) => {
         clearError();


### PR DESCRIPTION
## 概要

- Actions実行時に使用したテキストをBase UI Accordionで確認できるように追加
- popupからbackgroundへSummaryTargetを渡し、同じテキストで実行するように統一

## 種別

- [x] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- なし -->

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm typecheck && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
