### PR TITLE
fix: storybook optimizeDeps に React ランタイム追加

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -65,6 +65,9 @@ const config: StorybookConfig = {
     viteConfig.optimizeDeps.include = Array.from(
       new Set([
         ...include,
+        "react",
+        "react/jsx-runtime",
+        "react/jsx-dev-runtime",
         "date-fns",
         "react-dom",
         "react-dom/client",


### PR DESCRIPTION
## 概要

Storybook/Vitest の動的 import 失敗を防ぐため、optimizeDeps.include に React ランタイムを追加。

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue



## 確認済み

- [x] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
