### PR TITLE
popupのCSS読み込み先をsrc/stylesへ修正

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -7,24 +7,24 @@
     <link
       id="mbu-ui-token-primitives"
       rel="stylesheet"
-      href="dist/styles/tokens/primitives.css"
+      href="./src/styles/tokens/primitives.css"
     >
     <link
       id="mbu-ui-token-semantic"
       rel="stylesheet"
-      href="dist/styles/tokens/semantic.css"
+      href="./src/styles/tokens/semantic.css"
     >
-    <link id="mbu-style-base" rel="stylesheet" href="dist/styles/base.css">
-    <link id="mbu-style-layout" rel="stylesheet" href="dist/styles/layout.css">
+    <link id="mbu-style-base" rel="stylesheet" href="./src/styles/base.css">
+    <link id="mbu-style-layout" rel="stylesheet" href="./src/styles/layout.css">
     <link
       id="mbu-style-utilities"
       rel="stylesheet"
-      href="dist/styles/utilities.css"
+      href="./src/styles/utilities.css"
     >
     <link
       id="mbu-ui-base-styles"
       rel="stylesheet"
-      href="dist/styles/tokens/components.css"
+      href="./src/styles/tokens/components.css"
     >
   </head>
   <body>


### PR DESCRIPTION
## 概要

popupのスタイル参照をdistからsrc/stylesに切り替え、Storybookと実際の表示差分を解消。Chrome DevToolsで `file://` 版popupの表示確認済み。`mise run ci` 実行済み。

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue


## 確認済み

- [x] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
