### PR TITLE
トークン入力の右端に表示/非表示アイコンを追加

### DIFF
--- a/src/components/icon.stories.tsx
+++ b/src/components/icon.stories.tsx
@@ -16,6 +16,8 @@ const iconNames: IconName[] = [
   "pin",
   "copy",
   "close",
+  "eye",
+  "eye-off",
 ];
 
 function IconGallery(): React.JSX.Element {

--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -1,6 +1,8 @@
 import {
   Calendar,
   Copy,
+  Eye,
+  EyeOff,
   Link,
   type LucideProps,
   Menu,
@@ -18,6 +20,8 @@ export type IconName =
   | "calendar"
   | "close"
   | "copy"
+  | "eye"
+  | "eye-off"
   | "link"
   | "menu"
   | "monitor"
@@ -32,6 +36,8 @@ const icons: Record<IconName, React.ComponentType<LucideProps>> = {
   calendar: Calendar,
   close: X,
   copy: Copy,
+  eye: Eye,
+  "eye-off": EyeOff,
   link: Link,
   menu: Menu,
   monitor: Monitor,

--- a/src/popup/panes/SettingsPane.tsx
+++ b/src/popup/panes/SettingsPane.tsx
@@ -10,6 +10,7 @@ import { Separator } from "@base-ui/react/separator";
 import { Toggle } from "@base-ui/react/toggle";
 import { Result } from "@praha/byethrow";
 import { useEffect, useId, useState } from "react";
+import { Icon } from "@/components/icon";
 import {
   DEFAULT_OPENAI_MODEL,
   normalizeOpenAiModel,
@@ -427,26 +428,34 @@ export function SettingsPane(props: SettingsPaneProps): React.JSX.Element {
 
           <label className="field" htmlFor={tokenInputId}>
             <span className="field-name">トークン</span>
-            <Input
-              className="token-input"
-              data-testid="openai-token"
-              id={tokenInputId}
-              onValueChange={setToken}
-              ref={props.tokenInputRef}
-              type={showToken ? "text" : "password"}
-              value={token}
-            />
+            <div className="input-with-icon">
+              <Input
+                className="token-input token-input--with-icon"
+                data-testid="openai-token"
+                id={tokenInputId}
+                onValueChange={setToken}
+                ref={props.tokenInputRef}
+                type={showToken ? "text" : "password"}
+                value={token}
+              />
+              <Toggle
+                aria-controls={tokenInputId}
+                aria-label={showToken ? "トークンを隠す" : "トークンを表示する"}
+                className="input-icon-toggle"
+                data-testid="token-visible"
+                onPressedChange={setShowToken}
+                pressed={showToken}
+                title={showToken ? "トークンを隠す" : "トークンを表示する"}
+                type="button"
+              >
+                <Icon
+                  aria-hidden="true"
+                  name={showToken ? "eye-off" : "eye"}
+                  size={16}
+                />
+              </Toggle>
+            </div>
           </label>
-
-          <Toggle
-            className="mbu-toggle"
-            data-testid="token-visible"
-            onPressedChange={setShowToken}
-            pressed={showToken}
-            type="button"
-          >
-            表示する
-          </Toggle>
         </Fieldset.Root>
 
         <div className="button-row">

--- a/src/styles/tokens/components.css
+++ b/src/styles/tokens/components.css
@@ -1270,6 +1270,49 @@ body.no-js:has(.pane:target) .pane.active:not(:target) {
   font-size: var(--primitive-font-size-14);
 }
 
+.input-with-icon {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.token-input--with-icon {
+  padding-right: 40px;
+}
+
+.input-icon-toggle {
+  position: absolute;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-sub);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+
+.input-icon-toggle:hover {
+  background: color-mix(in oklab, var(--color-text) 6%, transparent);
+}
+
+.input-icon-toggle[data-pressed] {
+  color: var(--text);
+  border-color: color-mix(in oklab, var(--color-primary) 35%, var(--line));
+  background: color-mix(
+    in oklab,
+    var(--color-primary) var(--accent-mix-14),
+    transparent
+  );
+}
+
+.input-icon-toggle svg {
+  width: 16px;
+  height: 16px;
+}
+
 .mbu-select-trigger {
   width: 100%;
   display: flex;


### PR DESCRIPTION
## 概要

- OpenAI APIトークン入力に右端アイコンの表示/非表示トグルを追加
- Eye/EyeOffアイコンを追加

## 種別

- [x] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

- なし

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
