### PR TITLE
chore(ci): ワークフロージョブ名を統一

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   unified-quality-gate:
-    name: Gate: Quality
+    name: Quality Gate
     runs-on: ubuntu-latest
     needs: [detect-changes, actionlint, lint, test, build, storybook, docs-quality-gate]
     if: always()


### PR DESCRIPTION
## 概要

ワークフローのジョブ名を"Prep/Check/Gate"表記に統一しつつ、必須チェックとして登録されている"Quality Gate"の名前を維持してステータスが報告されるように調整しました。

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [ ] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [x] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->