### PR TITLE
Overlay toastをパネル右端に揃える

### DIFF
--- a/src/content/overlay/OverlayApp.tsx
+++ b/src/content/overlay/OverlayApp.tsx
@@ -57,9 +57,9 @@ const OVERLAY_TOAST_GAP_PX = 8;
 const OVERLAY_TOAST_ESTIMATED_HEIGHT_PX = 52;
 const OVERLAY_TOAST_SAFE_MARGIN_PX = 16;
 const OVERLAY_PINNED_MARGIN_PX = 16;
-const OVERLAY_TOAST_SURFACE_INSET_BELOW = `calc(100% + ${OVERLAY_TOAST_GAP_PX}px) 12px auto 12px`;
-const OVERLAY_TOAST_SURFACE_INSET_ABOVE = `auto 12px calc(100% + ${OVERLAY_TOAST_GAP_PX}px) 12px`;
-const OVERLAY_TOAST_SURFACE_INSET_INSIDE = "auto 12px 12px 12px";
+const OVERLAY_TOAST_SURFACE_INSET_BELOW = `calc(100% + ${OVERLAY_TOAST_GAP_PX}px) 0 auto 12px`;
+const OVERLAY_TOAST_SURFACE_INSET_ABOVE = `auto 0 calc(100% + ${OVERLAY_TOAST_GAP_PX}px) 12px`;
+const OVERLAY_TOAST_SURFACE_INSET_INSIDE = "auto 0 12px 12px";
 
 // Regex patterns at module level for performance (lint/performance/useTopLevelRegex)
 const SELECTION_SECONDARY_REGEX = /^選択範囲:\s*\n([\s\S]*)$/;

--- a/src/styles/tokens/components.css
+++ b/src/styles/tokens/components.css
@@ -214,7 +214,7 @@
 :host(#my-browser-utils-overlay) {
   top: 16px;
   left: 16px;
-  --toast-surface-inset: calc(100% + 8px) 12px auto 12px;
+  --toast-surface-inset: calc(100% + 8px) 0 auto 12px;
 }
 
 :host,


### PR DESCRIPTION
## 概要

オーバーレイのトーストをパネル右端に揃えるため、surface inset の右側を 0px に調整しました。

## 種別

- [ ] 🚀 feature (新機能)
- [x] 🐛 fix (バグ修正)
- [ ] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

なし

## 確認済み

- [x] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
