### PR TITLE
popup: ハッシュ更新の共通化

### DIFF
--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -4,6 +4,7 @@ import { Result } from "@praha/byethrow";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { APP_NAME } from "@/app_meta";
 import { Icon } from "@/components/icon";
+import { replaceHashSafely } from "@/popup/hash";
 import { coercePaneId, getPaneIdFromHash, type PaneId } from "@/popup/panes";
 import { ActionsPane } from "@/popup/panes/ActionsPane";
 import { CalendarPane } from "@/popup/panes/CalendarPane";
@@ -14,17 +15,6 @@ import { createPopupRuntime } from "@/popup/runtime";
 import type { CopyTitleLinkFailure } from "@/storage/types";
 import { createNotifications, ToastHost } from "@/ui/toast";
 import { coerceLinkFormat, type LinkFormat } from "@/utils/link_format";
-
-function replaceHash(nextHash: string): void {
-  try {
-    if (window.location.hash === nextHash) {
-      return;
-    }
-    window.history.replaceState(null, "", nextHash);
-  } catch {
-    window.location.hash = nextHash;
-  }
-}
 
 function canUseChromeAction(runtime: { isExtensionPage: boolean }): boolean {
   return (
@@ -219,7 +209,7 @@ export function PopupApp(): React.JSX.Element {
   }, [syncFromHash]);
 
   useEffect(() => {
-    replaceHash(`#${tabValue}`);
+    replaceHashSafely(window, `#${tabValue}`);
   }, [tabValue]);
 
   useEffect(() => {

--- a/src/popup/hash.ts
+++ b/src/popup/hash.ts
@@ -1,0 +1,10 @@
+export function replaceHashSafely(window: Window, nextHash: string): void {
+  try {
+    if (window.location.hash === nextHash) {
+      return;
+    }
+    window.history.replaceState(null, "", nextHash);
+  } catch {
+    window.location.hash = nextHash;
+  }
+}


### PR DESCRIPTION
## 概要

- ポップアップのハッシュ更新処理を共通化して重複を削減
- メニューのフォーカス遷移を共通ヘルパーで整理

## 種別

- [ ] 🚀 feature (新機能)
- [ ] 🐛 fix (バグ修正)
- [x] 🔧 chore (その他)
- [ ] 💥 breaking (破壊的変更)

## 影響範囲

- [x] フロントエンド
- [ ] API
- [ ] Terraform/インフラ
- [ ] CI/CD
- [ ] ドキュメント

## 関連Issue

<!-- fixes #123 形式で記載、複数ある場合は改行して記載 -->

## 確認済み

- [ ] 動作確認完了
- [x] 品質チェック通過 (`pnpm lint && pnpm type-check && pnpm build`)
- [ ] Terraform変更時: `terraform validate && terraform plan`

---

<!-- CodeRabbitの自動生成コメントはここに挿入されます -->
