### PR TITLE
feat: カンマ区切り金額のテーブルソート対応

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -15,6 +15,7 @@ import {
   ToastHost,
   type ToastManager,
 } from "@/ui/toast";
+import { parseNumericValue } from "@/utils/number_parser";
 
 // Regex patterns at module level for performance (lint/performance/useTopLevelRegex)
 const QUERY_OR_HASH_REGEX = /[?#]/;
@@ -163,6 +164,7 @@ const SOURCE_SUFFIX_REGEX = /（(?:選択範囲|ページ本文)）\s*$/;
   type ContentTestHooks = {
     patternToRegex?: (pattern: string) => RegExp;
     matchesAnyPattern?: (patterns: string[]) => boolean;
+    parseNumericValue?: (text: string) => number;
   };
 
   const testHooks = (
@@ -171,6 +173,7 @@ const SOURCE_SUFFIX_REGEX = /（(?:選択範囲|ページ本文)）\s*$/;
   if (testHooks) {
     testHooks.patternToRegex = patternToRegex;
     testHooks.matchesAnyPattern = matchesAnyPattern;
+    testHooks.parseNumericValue = parseNumericValue;
   }
 
   // 2回目以降の初期化では副作用を追加しない（idempotent）
@@ -238,8 +241,8 @@ const SOURCE_SUFFIX_REGEX = /（(?:選択範囲|ページ本文)）\s*$/;
       const aCell = a.cells[columnIndex]?.textContent?.trim() ?? "";
       const bCell = b.cells[columnIndex]?.textContent?.trim() ?? "";
 
-      const aNum = Number.parseFloat(aCell);
-      const bNum = Number.parseFloat(bCell);
+      const aNum = parseNumericValue(aCell);
+      const bNum = parseNumericValue(bCell);
 
       if (!(Number.isNaN(aNum) || Number.isNaN(bNum))) {
         return isAscending ? aNum - bNum : bNum - aNum;

--- a/src/utils/number_parser.ts
+++ b/src/utils/number_parser.ts
@@ -1,0 +1,47 @@
+// Module-level regex patterns (lint/performance/useTopLevelRegex)
+const CURRENCY_SYMBOLS_REGEX = /[¥$€£円元]/;
+const NUMBER_WITH_SEPARATORS_REGEX =
+  /^[¥$€£円元]?\s*-?[\d,]+\.?\d*\s*[¥$€£円元]?$/;
+const SEPARATOR_CHARS_REGEX = /[,]/g;
+
+/**
+ * 文字列から数値を抽出する
+ *
+ * サポート形式:
+ * - 通貨記号付き: "935円", "$1,000", "¥254,079"
+ * - カンマ区切り: "1,000,000"
+ * - 小数点: "123.45"
+ * - 負の数: "-100円"
+ * - 指数表記: "1e3" (1000)
+ *
+ * @param text - パース対象の文字列
+ * @returns 数値またはNaN
+ *
+ * @example
+ * parseNumericValue("254,079円") // 254079
+ * parseNumericValue("$1,234.56") // 1234.56
+ * parseNumericValue("abc") // NaN
+ */
+export function parseNumericValue(text: string): number {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return Number.NaN;
+  }
+
+  // 通貨記号を含む数値形式かチェック
+  const hasCurrency = CURRENCY_SYMBOLS_REGEX.test(trimmed);
+  const isNumericLike = NUMBER_WITH_SEPARATORS_REGEX.test(trimmed);
+
+  if (hasCurrency || isNumericLike) {
+    // 通貨記号とカンマを削除
+    const cleaned = trimmed
+      .replace(CURRENCY_SYMBOLS_REGEX, "")
+      .replace(SEPARATOR_CHARS_REGEX, "")
+      .trim();
+
+    return Number.parseFloat(cleaned);
+  }
+
+  // 通常の数値パース（指数表記などもサポート）
+  return Number.parseFloat(trimmed);
+}

--- a/tests/utils.number_parser.test.ts
+++ b/tests/utils.number_parser.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { parseNumericValue } from "@/utils/number_parser";
+
+describe("parseNumericValue", () => {
+  describe("通貨記号付き数値", () => {
+    it("日本円（後置）", () => {
+      expect(parseNumericValue("935円")).toBe(935);
+      expect(parseNumericValue("254,079円")).toBe(254_079);
+      expect(parseNumericValue("1,000,000円")).toBe(1_000_000);
+    });
+
+    it("日本円（前置）", () => {
+      expect(parseNumericValue("¥935")).toBe(935);
+      expect(parseNumericValue("¥254,079")).toBe(254_079);
+    });
+
+    it("ドル", () => {
+      expect(parseNumericValue("$1,234.56")).toBe(1234.56);
+      expect(parseNumericValue("$1000")).toBe(1000);
+    });
+
+    it("その他の通貨", () => {
+      expect(parseNumericValue("€1,234.56")).toBe(1234.56);
+      expect(parseNumericValue("£999.99")).toBe(999.99);
+      expect(parseNumericValue("1,234元")).toBe(1234);
+    });
+  });
+
+  describe("カンマ区切り数値", () => {
+    it("整数", () => {
+      expect(parseNumericValue("1,000")).toBe(1000);
+      expect(parseNumericValue("1,000,000")).toBe(1_000_000);
+      expect(parseNumericValue("123,456,789")).toBe(123_456_789);
+    });
+
+    it("小数", () => {
+      expect(parseNumericValue("1,234.56")).toBe(1234.56);
+      expect(parseNumericValue("999,999.99")).toBe(999_999.99);
+    });
+  });
+
+  describe("通常の数値", () => {
+    it("整数", () => {
+      expect(parseNumericValue("123")).toBe(123);
+      expect(parseNumericValue("0")).toBe(0);
+    });
+
+    it("小数", () => {
+      expect(parseNumericValue("123.456")).toBe(123.456);
+      expect(parseNumericValue("0.5")).toBe(0.5);
+    });
+
+    it("指数表記", () => {
+      expect(parseNumericValue("1e3")).toBe(1000);
+      expect(parseNumericValue("1.5e2")).toBe(150);
+    });
+  });
+
+  describe("負の数", () => {
+    it("通貨記号付き", () => {
+      expect(parseNumericValue("-100円")).toBe(-100);
+      expect(parseNumericValue("-$50.00")).toBe(-50);
+    });
+
+    it("カンマ区切り", () => {
+      expect(parseNumericValue("-1,000")).toBe(-1000);
+    });
+
+    it("通常の数値", () => {
+      expect(parseNumericValue("-123")).toBe(-123);
+    });
+  });
+
+  describe("エッジケース", () => {
+    it("空白を含む", () => {
+      expect(parseNumericValue("  935円  ")).toBe(935);
+      expect(parseNumericValue("$ 1,000")).toBe(1000);
+    });
+
+    it("空文字列", () => {
+      expect(Number.isNaN(parseNumericValue(""))).toBe(true);
+      expect(Number.isNaN(parseNumericValue("   "))).toBe(true);
+    });
+
+    it("数値でない文字列", () => {
+      expect(Number.isNaN(parseNumericValue("abc"))).toBe(true);
+      expect(Number.isNaN(parseNumericValue("価格未定"))).toBe(true);
+      expect(Number.isNaN(parseNumericValue("N/A"))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## 概要

テーブルソート機能で、カンマ区切りの金額（"254,079円"、"$1,234.56"など）が正しくソートされるように改善しました。

## 問題

現在の実装では `Number.parseFloat("254,079円")` が **254** に変換されるため、カンマで数値解析が停止し、大きな金額が小さく判定されていました。

**例**: "935円" > "254,079円" と誤ったソート

## 解決方法

### 1. 新規ユーティリティ関数の追加

**ファイル**: `src/utils/number_parser.ts`

- `parseNumericValue()` 関数を実装
- カンマ除去、通貨記号対応、負の数対応

### 2. sortTable 関数の修正

**ファイル**: `src/content.ts`

- `Number.parseFloat()` → `parseNumericValue()` に変更（2行のみ）
- import文追加（1行）
- テストフック追加（2行）

### 3. 包括的なテストケース

**ファイル**: `tests/utils.number_parser.test.ts`

- 15テストケース追加
- 通貨記号（円、ドル、ユーロ、ポンド、元）
- カンマ区切り、負の数、小数点、エッジケース

## サポート対象

- 日本円（"935円"、"¥254,079"）
- ドル（"$1,234.56"）
- その他通貨（€, £, 元）
- カンマ区切り（"1,000,000"）
- 負の数（"-100円"）
- 小数点（"123.45"）

## テスト計画

### 自動テスト

- [x] 型チェック: エラー0件
- [x] 単体テスト: 98/98 成功（新規15テスト含む）
- [x] リント: エラー0件
- [x] ビルド: 成功

### 手動テスト

- [ ] 拡張機能の再読み込み（`chrome://extensions/` → 「更新」ボタン）
- [ ] クレジットカード利用残高テーブルでソート動作確認
  - 昇順: 0円 → 600円 → 935円 → ... → 254,079円
  - 降順: 254,079円 → ... → 935円 → 600円 → 0円
- [ ] 既存の数値ソート機能が正常動作（後方互換性確認）

## 技術的考慮事項

- **パフォーマンス**: 正規表現をモジュールレベルで定義（Biomeルール準拠）
- **後方互換性**: 既存の数値ソート機能は影響なし
- **拡張性**: 新しい通貨記号も簡単に追加可能

## 関連Issue

Closes #（該当するissue番号があれば記載）