### PR TITLE
fix: remove backticks from mention templates

### DIFF
--- a/src/text_templates.ts
+++ b/src/text_templates.ts
@@ -42,25 +42,25 @@ export const DEFAULT_TEXT_TEMPLATES: TextTemplate[] = [
   {
     id: "template:greptileai-review-390917b4",
     title: "greptileai review",
-    content: "`@greptileai` review",
+    content: "@greptileai review",
     hidden: false,
   },
   {
     id: "template:coderabbit-review-0f6905e9",
     title: "coderabbitai review",
-    content: "`@coderabbitai` review",
+    content: "@coderabbitai review",
     hidden: false,
   },
   {
     id: "template:greptileai-improve-49248104",
     title: "greptileai improve",
-    content: "`@greptileai` コードの改善は可能ですか？",
+    content: "@greptileai コードの改善は可能ですか？",
     hidden: false,
   },
   {
     id: "template:greptileai-accept-56305a04",
     title: "greptileai accept",
-    content: "`@greptileai` 許容してください",
+    content: "@greptileai 許容してください",
     hidden: false,
   },
 ];


### PR DESCRIPTION
## 概要

GitHubのメンションとして機能させるため、テキストテンプレートの`@greptileai`と`@coderabbitai`からバッククォートを削除しました。

## 変更内容

### 修正前

```typescript
content: "`@greptileai` review",
```

### 修正後

```typescript
content: "@greptileai review",
```

### 対象テンプレート

- 🔧 `@greptileai review`
- 🔧 `@greptileai コードの改善は可能ですか?`
- 🔧 `@greptileai 許容してください`
- 🔧 `@coderabbitai review`

## 理由

バッククォートで囲まれた `` `@greptileai` `` はGitHubのMarkdownでコードとして扱われ、メンションとして機能しませんでした。バッククォートを削除することで、GitHubのコメント欄で正しくメンション通知が届くようになります。

## テスト計画

- [x] 既存のテストがすべて成功することを確認
- [x] フォーマットが適用されていることを確認
- [x] `mise run ci` で品質チェック完全通過（テスト158件成功、Storybook 55件成功）

## チェックリスト

- [x] コードフォーマット適用済み
- [x] 品質チェック完了
- [x] 既存機能への影響なし

🤖 Generated with [Claude Code](https://claude.ai/code)