### PR TITLE
fix: improve error logging in handleTemplateClick

### DIFF
--- a/src/background/context_menu_registry.ts
+++ b/src/background/context_menu_registry.ts
@@ -540,11 +540,11 @@ async function handleTemplateClick(
     .catch((error) => {
       debugLog(
         "handleTemplateClick",
-        "chrome.tabs.sendMessage failed",
+        "Failed to paste template. Content script may not be loaded on this page.",
         {
           tabId,
           templateId,
-          error: formatErrorLog("", {}, error),
+          error: formatErrorLog("sendMessage error", {}, error),
         },
         "error"
       ).catch(() => {


### PR DESCRIPTION
## 概要

テンプレート貼り付け時のエラーログが `[object Object]` と表示され、詳細が確認できない問題を修正しました。

- 🐛 エラーログのラベルを追加（`formatErrorLog` の第1引数を空文字列から `"sendMessage error"` に変更）
- 📝 エラーメッセージをより具体的に改善

## 変更内容

### コミット数 (1)

**Fix**
- src/background/context_menu_registry.ts

## 変更詳細

### エラーログの改善

**変更前**:
```typescript
error: formatErrorLog("", {}, error)
```

**変更後**:
```typescript
error: formatErrorLog("sendMessage error", {}, error)
```

### エラーメッセージの改善

**変更前**:
```
chrome.tabs.sendMessage failed
```

**変更後**:
```
Failed to paste template. Content script may not be loaded on this page.
```

これにより、エラーログが読みやすくなり、エラー原因（content scriptが読み込まれていないページでの実行）が明確になります。

## テスト計画

- [x] ビルドが成功することを確認
- [x] エラーログのフォーマットが正しいことを確認
- [ ] 実際にエラーが発生する状況（新しいタブ、chrome://ページなど）でエラーメッセージを確認

## チェックリスト

- [x] コードフォーマット適用済み
- [x] 型チェック成功
- [x] 既存機能への影響なし
- [x] エラーハンドリングの改善

🤖 Generated with [Claude Code](https://claude.ai/code)